### PR TITLE
fix(ui): contain chat scroll and theme picker

### DIFF
--- a/apps/web/src/chat/ModelPicker.tsx
+++ b/apps/web/src/chat/ModelPicker.tsx
@@ -53,24 +53,16 @@ export function ModelPicker({ conversationId }: { conversationId: string }) {
 
 	if (models.length === 0) {
 		return (
-			<div style={{ padding: "0.5rem 1rem", color: "#999", fontSize: 13 }}>
+			<div className="border-b border-base-300 px-4 py-2 text-sm text-base-content/60">
 				No models configured.
 			</div>
 		);
 	}
 
 	return (
-		<div
-			style={{
-				display: "flex",
-				alignItems: "center",
-				gap: 8,
-				padding: "0.4rem 1rem",
-				borderBottom: "1px solid #eee",
-				fontSize: 13,
-			}}
-		>
+		<div className="flex items-center gap-2 border-b border-base-300 px-4 py-1.5 text-sm">
 			<select
+				className="select select-sm"
 				value={cur ? key(cur) : ""}
 				onChange={(e) => {
 					const m = models.find((x) => key(x) === e.target.value);

--- a/apps/web/src/chat/Thread.tsx
+++ b/apps/web/src/chat/Thread.tsx
@@ -951,6 +951,7 @@ export function Thread({
 				style={{
 					flex: 1,
 					overflowY: "auto",
+					overscrollBehaviorY: "contain",
 					padding: "1rem",
 					display: "flex",
 					flexDirection: "column",


### PR DESCRIPTION
## Summary
Theme the conversation model picker with DaisyUI semantic tokens and stop edge drags in the chat history from scrolling the surrounding page.

## Changes
- **Model picker**: use the DaisyUI small select and theme-aware base colors for the divider and empty state.
- **Chat thread**: contain vertical overscroll within the message-history viewport.

## Testing
- Verified the model picker visually in the browser.
- Confirmed the thread viewport computes `overscroll-behavior-y: contain`.
