### PR TITLE
Stabilize streamed Markdown citation rendering

### DIFF
--- a/apps/web/src/chat/MarkdownText.tsx
+++ b/apps/web/src/chat/MarkdownText.tsx
@@ -140,8 +140,16 @@ function SourceFavicon({ citation }: { citation: Citation }) {
  * Markdown `a` override: external http(s) links render as a compact source
  * pill (favicon + link text); everything else renders as a plain link.
  */
-function InlineSource({ href, children, ...props }: ComponentProps<"a">) {
-	const citation = typeof href === "string" ? citationFromLink("", href) : null;
+function InlineSource({
+	href,
+	children,
+	renderAsCitation,
+	...props
+}: ComponentProps<"a"> & { renderAsCitation: boolean }) {
+	const citation =
+		renderAsCitation && typeof href === "string"
+			? citationFromLink("", href)
+			: null;
 	if (!citation) {
 		return (
 			<a href={href} target="_blank" rel="noreferrer" {...props}>
@@ -308,7 +316,10 @@ export function PlainMarkdown({ text }: { text: string }) {
 export function MarkdownText() {
 	const dark = useDarkTheme();
 	const text = useAuiState((s) => (s.part.type === "text" ? s.part.text : ""));
-	const citations = citationsFrom(text);
+	const isStreaming = useAuiState((s) => s.part.status.type === "running");
+	// Citation parsing changes the rendered body (footer removal and source pills).
+	// Wait for the text part to settle so streamed chunks do not repeatedly shift it.
+	const citations = isStreaming ? [] : citationsFrom(text);
 	const trpc = useTRPC();
 	const citationUrls = citations
 		.map((citation) => citation.url)
@@ -329,7 +340,9 @@ export function MarkdownText() {
 				// Convert `\[…\]` / `\(…\)` to `$$…$$` / `$…$` before markdown parsing,
 				// so KaTeX sees the math (markdown would otherwise escape the brackets).
 				preprocess={(value) =>
-					rewriteLatexBracketDelimiters(removeCitationBlocks(value))
+					rewriteLatexBracketDelimiters(
+						isStreaming ? value : removeCitationBlocks(value),
+					)
 				}
 				remarkPlugins={[remarkGfm, remarkMath]}
 				rehypePlugins={[rehypeKatex]}
@@ -337,7 +350,9 @@ export function MarkdownText() {
 					SyntaxHighlighter: (props) => (
 						<CodeHighlighter {...props} dark={dark} />
 					),
-					a: InlineSource,
+					a: (props) => (
+						<InlineSource {...props} renderAsCitation={!isStreaming} />
+					),
 				}}
 			/>
 			<CitationSources citations={citations} categories={categories} />

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -17,7 +17,7 @@
       "source": "saadeghi/daisyui",
       "sourceType": "github",
       "skillPath": "skills/daisyui/SKILL.md",
-      "computedHash": "92b9228e8f5325c1d44a3aa820f2af310743307ea978bb86faff118c6864e9ea"
+      "computedHash": "9e350fa9ff3694d217288a1f3efa4ba5eae3d6f384991b97fd2b6426a22b7474"
     },
     "frontend-design": {
       "source": "anthropics/skills",


### PR DESCRIPTION
## Summary

Defer citation parsing and source-pill rendering until streamed assistant text has finished, preventing the message body from repeatedly shifting as chunks arrive.

## Details

- Detect running text parts in `MarkdownText` and temporarily skip citation extraction while streaming.
- Preserve raw links during streaming; once complete, external links render as citation source pills again.
- Avoid removing citation blocks from the Markdown input until streaming settles.
- Continue rendering LaTeX, GFM, syntax-highlighted code, and regular links during streaming.
- Regenerate the DaisyUI skill lock hash in `skills-lock.json`.

This keeps incremental assistant responses visually stable while preserving the existing citation footer and inline source behavior for completed messages.