### PR TITLE
chore(deps): upgrade to Bun 1.4.0 and use native Bun.Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.3.14
+FROM oven/bun:1.4.0
 
 WORKDIR /app
 

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -27,7 +27,6 @@
     "better-auth": "^1.6.23",
     "bun-plugin-tailwind": "^0.1.2",
     "hono": "^4.6.0",
-    "image-size": "^2.0.2",
     "kysely": "^0.27.4",
     "kysely-bun-sqlite": "^0.4.0",
     "loglayer": "^9.4.0",

--- a/apps/server/src/chat/attachments.ts
+++ b/apps/server/src/chat/attachments.ts
@@ -1,6 +1,5 @@
 import type { ImageContent, TextContent } from "@earendil-works/pi-ai";
 import { DiskResource, PathSpec } from "@struktoai/mirage-node";
-import { imageSize } from "image-size";
 import { config } from "../config";
 import { db } from "../db";
 import type { AttachmentKind } from "../db/schema";
@@ -60,12 +59,12 @@ function classify(mimeType: string): AttachmentKind | null {
 	return null;
 }
 
-function dimensions(bytes: Uint8Array): {
+async function dimensions(bytes: Uint8Array): Promise<{
 	width: number | null;
 	height: number | null;
-} {
+}> {
 	try {
-		const { width, height } = imageSize(bytes);
+		const { width, height } = await new Bun.Image(bytes).metadata();
 		if (typeof width === "number" && typeof height === "number") {
 			return { width, height };
 		}
@@ -91,7 +90,9 @@ export async function saveAttachmentFile(params: {
 		throw new AttachmentError("File exceeds the 20 MB limit");
 	}
 	const imageDimensions =
-		kind === "image" ? dimensions(params.bytes) : { width: null, height: null };
+		kind === "image"
+			? await dimensions(params.bytes)
+			: { width: null, height: null };
 	const documentMetadata =
 		params.mimeType === "application/pdf"
 			? await pdfMetadata(params.bytes).catch(() => ({

--- a/apps/web/build.ts
+++ b/apps/web/build.ts
@@ -9,6 +9,7 @@ await rm(outputDirectory, { recursive: true, force: true });
 const result = await Bun.build({
 	entrypoints: ["./index.html"],
 	outdir: outputDirectory,
+	reactCompiler: true,
 	define: { "process.env.NODE_ENV": JSON.stringify("production") },
 	minify: true,
 	plugins: [tailwind],

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "bun run build.ts",
-    "test": "bun test src",
+    "test": "bun test --parallel src",
     "test:watch": "bun test --watch src"
   },
   "dependencies": {

--- a/bun.lock
+++ b/bun.lock
@@ -12,9 +12,8 @@
       "devDependencies": {
         "@biomejs/biome": "^2.5.4",
         "@playwright/test": "^1.61.1",
-        "@types/bun": "^1.3.14",
         "agent-browser": "^0.32.2",
-        "bun-types": "^1.3.14",
+        "bun-types": "^1.4.0",
         "lefthook": "^2.1.10",
         "typescript": "^5.6.3",
       },
@@ -36,7 +35,6 @@
         "better-auth": "^1.6.23",
         "bun-plugin-tailwind": "^0.1.2",
         "hono": "^4.6.0",
-        "image-size": "^2.0.2",
         "kysely": "^0.27.4",
         "kysely-bun-sqlite": "^0.4.0",
         "loglayer": "^9.4.0",
@@ -789,8 +787,6 @@
 
     "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
-    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
-
     "@types/command-line-args": ["@types/command-line-args@5.2.3", "", {}, "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw=="],
 
     "@types/command-line-usage": ["@types/command-line-usage@5.0.4", "", {}, "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg=="],
@@ -933,7 +929,7 @@
 
     "bun-plugin-tailwind": ["bun-plugin-tailwind@0.1.2", "", { "peerDependencies": { "bun": ">=1.0.0" } }, "sha512-41jNC1tZRSK3s1o7pTNrLuQG8kL/0vR/JgiTmZAJ1eHwe0w5j6HFPKeqEk0WAD13jfrUC7+ULuewFBBCoADPpg=="],
 
-    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+    "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
@@ -1262,8 +1258,6 @@
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
     "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
-
-    "image-size": ["image-size@2.0.2", "", { "bin": { "image-size": "bin/image-size.js" } }, "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w=="],
 
     "immediate": ["immediate@3.0.6", "", {}, "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="],
 

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "codegen": " bun run --cwd apps/server codegen",
     "deploy:staging": "bun run scripts/deploy-staging.ts",
     "typecheck": "(tsc -p apps/server/tsconfig.json && tsc -p apps/web/tsconfig.json && tsc -p packages/shared/tsconfig.json && tsc -p tsconfig.e2e.json)",
-    "test": "(bun run test:server && bun run test:web)",
-    "test:server": "bun test --isolate apps/server/src",
+    "test": "bun run --parallel test:server test:web",
+    "test:server": "bun test --parallel apps/server/src",
     "test:web": "bun run --cwd apps/web test",
     "test:e2e": "node ./node_modules/@playwright/test/cli.js test --project=chromium",
     "test:e2e:all": "node ./node_modules/@playwright/test/cli.js test",
@@ -42,9 +42,8 @@
   "devDependencies": {
     "@biomejs/biome": "^2.5.4",
     "@playwright/test": "^1.61.1",
-    "@types/bun": "^1.3.14",
     "agent-browser": "^0.32.2",
-    "bun-types": "^1.3.14",
+    "bun-types": "^1.4.0",
     "lefthook": "^2.1.10",
     "typescript": "^5.6.3"
   }

--- a/paseo.json
+++ b/paseo.json
@@ -40,7 +40,7 @@
       "command": "bun run --cwd apps/server codegen"
     },
     "test": {
-      "command": "bun test --isolate apps/server/src && bun run --cwd apps/web test"
+      "command": "bun run test"
     }
   },
   "metadataGeneration": {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,7 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
-    "types": ["bun"],
+    "types": ["bun-types"],
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "esModuleInterop": true,


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary
Upgrade the runtime and web build to Bun 1.4.0 while replacing the external image-dimension parser with Bun’s native image metadata API.

## Changes
- Update the Docker base image from Bun 1.3.14 to 1.4.0.
- Replace `image-size` with `Bun.Image(...).metadata()` for image width and height extraction.
- Make image-dimension extraction asynchronous and await it during attachment saving.
- Preserve null dimensions when metadata is unavailable or the attachment is not an image.
- Enable Bun’s React Compiler for production web builds.

## Functional Impact
Image attachments continue to store their dimensions, but metadata extraction now uses the Bun runtime’s native API and no longer requires the `image-size` dependency.
<!-- kody-pr-summary:end -->