### PR TITLE
feat(auth): add optional OIDC/SSO sign-in and pin better-auth 1.7.2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,46 @@
 # Generate a production secret with: openssl rand -base64 32
 BETTER_AUTH_SECRET=replace-with-a-random-secret
 
+# Public base URL of this deployment. Every OAuth redirect URI derives from it.
+# Defaults to http://localhost:${PORT} outside production.
+BETTER_AUTH_URL=
+
 # Google OAuth credentials. Redirect URI: ${BETTER_AUTH_URL}/api/auth/callback/google
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
+
+# Optional OpenID Connect provider (Authentik, Keycloak, Zitadel, Authelia).
+# Enabled once issuer and both credentials are set. Register this redirect URI
+# at the provider: ${BETTER_AUTH_URL}/api/auth/callback/oidc
+# Issuer examples:
+#   Authentik https://auth.example.com/application/o/solar/
+#   Keycloak  https://kc.example.com/realms/solar
+#   Zitadel   https://your-instance.zitadel.cloud
+#   Authelia  https://auth.example.com
+OIDC_ISSUER=
+OIDC_CLIENT_ID=
+OIDC_CLIENT_SECRET=
+
+# Sign-in button label: "Continue with <name>"
+OIDC_DISPLAY_NAME=SSO
+
+# Space- or comma-separated. Add the scope carrying group membership when using
+# role mapping below (Authentik/Authelia "groups", Keycloak "roles").
+OIDC_SCOPES=openid profile email
+
+# Set to 1 to require that an admin create the account first, matching Google.
+# Left at 0, a first sign-in provisions the user (still subject to
+# AUTH_ALLOWED_DOMAINS).
+OIDC_DISABLE_SIGNUP=0
+
+# Optional: grant the admin role from a group claim, re-checked on every
+# sign-in. Both must be set. The claim must be present in the ID token or the
+# userinfo response. Claim examples:
+#   Authentik / Authelia  groups
+#   Keycloak              realm_access.roles
+#   Zitadel               urn:zitadel:iam:org:project:roles
+OIDC_ADMIN_CLAIM=
+OIDC_ADMIN_VALUE=
 
 # Optional: Cloudflare Radar API token with Account > Radar > Read permission.
 CLOUDFLARE_RADAR_API_TOKEN=

--- a/README.md
+++ b/README.md
@@ -220,7 +220,11 @@ policy; task-model and large-paste settings; and aggregated token usage.
 | Variable | Purpose |
 | --- | --- |
 | `BETTER_AUTH_SECRET` | Required signing secret; use 32+ random characters |
+| `BETTER_AUTH_URL` | Public base URL; every OAuth redirect URI derives from it |
 | `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | Optional Google OAuth credentials |
+| `OIDC_ISSUER` / `OIDC_CLIENT_ID` / `OIDC_CLIENT_SECRET` | Optional OpenID Connect provider; all three enable it |
+| `OIDC_DISPLAY_NAME` / `OIDC_SCOPES` / `OIDC_DISABLE_SIGNUP` | Sign-in button label, requested scopes, and whether first sign-in may provision |
+| `OIDC_ADMIN_CLAIM` / `OIDC_ADMIN_VALUE` | Optional group claim and value granting the admin role |
 | `CLOUDFLARE_RADAR_API_TOKEN` | Optional Cloudflare Radar token for source categories |
 | `SOLAR_AIRGAP_MODE` / `AIRGAP_MODE` | Set to `1`/`true`/`yes`/`on` to block outbound network calls |
 | `DATABASE_PATH` | SQLite file path |
@@ -239,6 +243,7 @@ When `SOLAR_AIRGAP_MODE` (or `AIRGAP_MODE`) is active (`1`, `true`, `yes`, or `o
 - **Geocoding** is disabled (browser GPS coordinates are kept, but no reverse-geocoding calls are made to OpenStreetMap Nominatim).
 - **Domain classification** uses local DB cache and bundled registries only, skipping Cloudflare Radar API lookups.
 - **Google OAuth** is disabled and hidden from sign-in options.
+- **OIDC sign-in stays enabled**: a self-hosted identity provider is the operator's own service, not a third-party call.
 - **Citation favicons** are replaced with inline SVG placeholders, suppressing remote favicon fetches in the browser.
 
 Source-category badges use a bundled registry of 300+ news domains derived from
@@ -250,6 +255,46 @@ Google OAuth is enabled when both Google credentials are set. Configure the
 Google OAuth redirect URI as `${BETTER_AUTH_URL}/api/auth/callback/google`.
 Google sign-ins use the verified Google email address to identify and link the
 account; accounts with different email addresses are not linked.
+
+### OIDC / SSO
+
+Solar can sign users in through one self-hosted OpenID Connect provider. Set
+`OIDC_ISSUER`, `OIDC_CLIENT_ID`, and `OIDC_CLIENT_SECRET` to enable it; the
+sign-in page then shows a "Continue with `OIDC_DISPLAY_NAME`" button. Endpoints
+are read from `${OIDC_ISSUER}/.well-known/openid-configuration`, and the flow
+uses PKCE.
+
+Register this redirect URI at the provider:
+
+```
+${BETTER_AUTH_URL}/api/auth/callback/oidc
+```
+
+Issuer values differ by product:
+
+| Provider | `OIDC_ISSUER` | Group claim |
+| --- | --- | --- |
+| Authentik | `https://auth.example.com/application/o/<slug>/` | `groups` |
+| Keycloak | `https://kc.example.com/realms/<realm>` | `realm_access.roles` |
+| Zitadel | `https://<instance>.zitadel.cloud` | `urn:zitadel:iam:org:project:roles` |
+| Authelia | `https://auth.example.com` | `groups` |
+
+A first sign-in creates the Solar account, subject to `AUTH_ALLOWED_DOMAINS`.
+Set `OIDC_DISABLE_SIGNUP=1` to require that an admin create the user first,
+matching Google's behaviour. An IdP identity is linked to an existing account
+when the email addresses match exactly; differing addresses are never linked.
+The first account on a fresh deployment becomes the admin however it signs in.
+
+Setting both `OIDC_ADMIN_CLAIM` and `OIDC_ADMIN_VALUE` maps a group to the admin
+role, re-checked on every OIDC sign-in, so removing someone from the group at
+the provider demotes them (and revokes their API keys) on their next sign-in.
+Solar refuses to demote the last remaining admin. The claim must reach Solar in
+the ID token or the userinfo response: on Keycloak add a mapper with "Add to ID
+token" or "Add to userinfo" enabled, and request whichever scope carries it via
+`OIDC_SCOPES`. Roles stay manually managed in Settings when these are unset.
+
+Sign-ins are PKCE-protected, and when the provider's discovery document
+advertises a JWKS endpoint the ID token's signature and nonce are verified too.
 
 ## Migrating legacy chat history
 
@@ -286,7 +331,8 @@ surface, PWA shell, and remote MCP integration are present; APIs and UI details
 may still evolve.
 
 The project deliberately does **not** include RAG/vector search, voice, image
-generation, channels, enterprise SSO, or horizontal multi-node scaling.
+generation, channels, multi-tenant enterprise SSO (SAML, per-organization
+providers), or horizontal multi-node scaling.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -262,7 +262,9 @@ Solar can sign users in through one self-hosted OpenID Connect provider. Set
 `OIDC_ISSUER`, `OIDC_CLIENT_ID`, and `OIDC_CLIENT_SECRET` to enable it; the
 sign-in page then shows a "Continue with `OIDC_DISPLAY_NAME`" button. Endpoints
 are read from `${OIDC_ISSUER}/.well-known/openid-configuration`, and the flow
-uses PKCE.
+uses PKCE. The issuer and discovered userinfo endpoint must use HTTPS; cleartext
+HTTP is accepted only for `localhost`, `127.0.0.1`, and `[::1]` development
+endpoints.
 
 Register this redirect URI at the provider:
 

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -14,7 +14,7 @@
 		"codegen": "kysely-codegen --dialect sqlite --url solar.db --out-file src/db/types.generated.ts"
 	},
 	"dependencies": {
-		"@better-auth/api-key": "^1.6.23",
+		"@better-auth/api-key": "1.7.2",
 		"@earendil-works/pi-agent-core": "0.80.10",
 		"@earendil-works/pi-ai": "0.80.10",
 		"@earendil-works/pi-coding-agent": "0.84.2",
@@ -24,7 +24,7 @@
 		"@solar/web": "workspace:*",
 		"@struktoai/mirage-node": "^0.0.3",
 		"@trpc/server": "^11.0.0",
-		"better-auth": "^1.6.23",
+		"better-auth": "1.7.2",
 		"bun-plugin-tailwind": "^0.1.2",
 		"hono": "^4.6.0",
 		"kysely": "^0.27.4",

--- a/apps/server/src/accountIssuer.test.ts
+++ b/apps/server/src/accountIssuer.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+
+process.env.DATABASE_PATH = ":memory:";
+delete process.env.OIDC_ISSUER;
+delete process.env.OIDC_CLIENT_ID;
+delete process.env.OIDC_CLIENT_SECRET;
+
+const { accountIssuerFor } = await import("./accountIssuer");
+
+describe("accountIssuerFor", () => {
+	test("refuses to invent an OIDC issuer when the provider is not configured", () => {
+		expect(() => accountIssuerFor("oidc")).toThrow(
+			/OIDC_ISSUER, OIDC_CLIENT_ID, and OIDC_CLIENT_SECRET/,
+		);
+	});
+});

--- a/apps/server/src/accountIssuer.ts
+++ b/apps/server/src/accountIssuer.ts
@@ -1,0 +1,23 @@
+import { config } from "./config";
+import { OIDC_PROVIDER_ID } from "./oidc";
+
+/**
+ * The namespace Better Auth 1.7 stores in `account.issuer` alongside
+ * `accountId`, which together identify an account uniquely.
+ *
+ * Every value here must match what the running provider writes, or an existing
+ * identity stops being recognised on the next sign-in and picks up a second
+ * account row. Credential accounts use a synthetic local namespace, Google
+ * declares its own issuer, and a generic OAuth provider uses its configured
+ * `accountIssuer` (pinned to `OIDC_ISSUER` by `buildOidcProviderConfig`).
+ * Anything else falls back to the documented synthetic OAuth form.
+ */
+export function accountIssuerFor(providerId: string): string {
+	if (providerId === CREDENTIAL_PROVIDER_ID) return CREDENTIAL_ACCOUNT_ISSUER;
+	if (providerId === "google") return "https://accounts.google.com";
+	if (providerId === OIDC_PROVIDER_ID && config.oidc) return config.oidc.issuer;
+	return `local:oauth:${encodeURIComponent(providerId)}`;
+}
+
+export const CREDENTIAL_PROVIDER_ID = "credential";
+export const CREDENTIAL_ACCOUNT_ISSUER = "local:credential";

--- a/apps/server/src/accountIssuer.ts
+++ b/apps/server/src/accountIssuer.ts
@@ -9,13 +9,22 @@ import { OIDC_PROVIDER_ID } from "./oidc";
  * identity stops being recognised on the next sign-in and picks up a second
  * account row. Credential accounts use a synthetic local namespace, Google
  * declares its own issuer, and a generic OAuth provider uses its configured
- * `accountIssuer` (pinned to `OIDC_ISSUER` by `buildOidcProviderConfig`).
- * Anything else falls back to the documented synthetic OAuth form.
+ * `accountIssuer` (pinned to `OIDC_ISSUER` by `buildOidcProviderConfig`). An
+ * OIDC row cannot be backfilled without that configuration because inventing a
+ * namespace would prevent the real identity from matching later. Anything else
+ * falls back to the documented synthetic OAuth form.
  */
 export function accountIssuerFor(providerId: string): string {
 	if (providerId === CREDENTIAL_PROVIDER_ID) return CREDENTIAL_ACCOUNT_ISSUER;
 	if (providerId === "google") return "https://accounts.google.com";
-	if (providerId === OIDC_PROVIDER_ID && config.oidc) return config.oidc.issuer;
+	if (providerId === OIDC_PROVIDER_ID) {
+		if (!config.oidc) {
+			throw new Error(
+				"Cannot backfill an OIDC account issuer without complete OIDC configuration; set OIDC_ISSUER, OIDC_CLIENT_ID, and OIDC_CLIENT_SECRET",
+			);
+		}
+		return config.oidc.issuer;
+	}
 	return `local:oauth:${encodeURIComponent(providerId)}`;
 }
 

--- a/apps/server/src/auth.test.ts
+++ b/apps/server/src/auth.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+
+process.env.DATABASE_PATH = ":memory:";
+process.env.AUTH_ALLOWED_DOMAINS = "example.com";
+
+const { auth } = await import("./auth");
+
+const validateUserInfo = auth.options.user?.validateUserInfo;
+
+function oidcIdentity(email: string) {
+	return {
+		user: { email },
+		source: {
+			action: "link-account" as const,
+			method: "oauth" as const,
+			oauth: { providerId: "oidc", profile: {} },
+		},
+	};
+}
+
+describe("OIDC email-domain validation", () => {
+	test("rejects an out-of-policy identity before account linking", async () => {
+		expect(validateUserInfo).toBeFunction();
+		expect(
+			await validateUserInfo?.(oidcIdentity("person@outside.example")),
+		).toEqual({
+			error: "EMAIL_DOMAIN_NOT_ALLOWED",
+			errorDescription: "Email domain is not allowed",
+		});
+	});
+
+	test("allows an in-policy OIDC identity", async () => {
+		expect(
+			await validateUserInfo?.(oidcIdentity("person@example.com")),
+		).toBeUndefined();
+	});
+
+	test("leaves non-OIDC identities to their existing validation paths", async () => {
+		expect(
+			await validateUserInfo?.({
+				...oidcIdentity("person@outside.example"),
+				source: {
+					action: "link-account",
+					method: "oauth",
+					oauth: { providerId: "google", profile: {} },
+				},
+			}),
+		).toBeUndefined();
+	});
+});

--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -1,9 +1,20 @@
 import { betterAuth, type BetterAuthPlugin } from "better-auth";
-import { APIError } from "better-auth/api";
+import { APIError, createAuthMiddleware } from "better-auth/api";
+import { genericOAuth } from "better-auth/plugins";
 import { apiKey } from "@better-auth/api-key";
+import {
+	CREDENTIAL_ACCOUNT_ISSUER,
+	CREDENTIAL_PROVIDER_ID,
+} from "./accountIssuer";
 import { config } from "./config";
 import { dialect, sqlite } from "./db";
 import { getSolarImpersonation } from "./impersonation";
+import {
+	buildOidcProviderConfig,
+	OAUTH_CALLBACK_PATH,
+	OIDC_PROVIDER_ID,
+	syncOidcRole,
+} from "./oidc";
 
 export const API_KEY_HEADER = "x-api-key";
 
@@ -13,7 +24,11 @@ function assertAllowedEmailDomain(email: string): void {
 	if (allowed.length === 0) return;
 	const domain = email.split("@").at(-1)?.toLowerCase();
 	if (!domain || !allowed.includes(domain)) {
+		// The OAuth callback turns a thrown error into a redirect only when the
+		// body carries a `code`. Without one the browser is left on the callback
+		// URL showing raw JSON instead of the sign-in page.
 		throw new APIError("FORBIDDEN", {
+			code: "EMAIL_DOMAIN_NOT_ALLOWED",
 			message: "Email domain is not allowed",
 		});
 	}
@@ -56,12 +71,14 @@ export const auth = betterAuth({
 	account: {
 		accountLinking: {
 			enabled: true,
-			trustedProviders: ["google"],
+			trustedProviders: ["google", OIDC_PROVIDER_ID],
 			allowDifferentEmails: false,
 			// This app has no local email-verification flow, so email/password
 			// accounts are never marked verified. Without this opt-out, Better Auth
-			// refuses to implicitly link a Google sign-in to an existing local
-			// account. Google's verified-email claim is the linking trust anchor.
+			// refuses to implicitly link a Google or OIDC sign-in to an existing
+			// local account. Trusting these providers by name is what allows the
+			// link; the identity anchor is the matching email address, since
+			// `allowDifferentEmails` stays off.
 			requireLocalEmailVerified: false,
 		},
 	},
@@ -77,6 +94,13 @@ export const auth = betterAuth({
 			rateLimit: { enabled: false },
 			enableSessionForAPIKeys: true,
 		}) as unknown as BetterAuthPlugin,
+		// Optional self-hosted identity provider. Since 1.7 it adds no routes of
+		// its own and rides the built-in social endpoints, `/sign-in/social` and
+		// `/callback/:id`, both covered by the `/api/auth/*` GET+POST forward in
+		// `index.ts`.
+		...(config.oidc
+			? [genericOAuth({ config: [buildOidcProviderConfig(config.oidc)] })]
+			: []),
 	],
 	user: {
 		additionalFields: {
@@ -86,13 +110,36 @@ export const auth = betterAuth({
 			isDisabled: { type: "boolean", defaultValue: false, input: false },
 		},
 	},
+	// Re-apply the admin role from the IdP's group claim after every OIDC
+	// sign-in. It cannot live in the provider's `mapProfileToUser`: fields it
+	// returns are filtered against the user schema and `role` is `input: false`,
+	// so the value would be dropped. By the time this runs the account row holds
+	// a fresh ID token and the session exists.
+	//
+	// `/callback/:id` is the shared OAuth callback, so Google arrives here too;
+	// the provider id is what selects OIDC sign-ins.
+	...(config.oidc?.adminClaim
+		? {
+				hooks: {
+					after: createAuthMiddleware(async (ctx) => {
+						if (ctx.path !== OAUTH_CALLBACK_PATH) return;
+						if (ctx.params?.id !== OIDC_PROVIDER_ID) return;
+						const newSession = ctx.context.newSession;
+						if (!newSession) return;
+						await syncOidcRole(newSession.user.id, ctx.context);
+					}),
+				},
+			}
+		: {}),
 	databaseHooks: {
 		user: {
 			create: {
 				// First account to register on a deployment becomes the admin.
 				before: async (user) => {
-					// Covers email/password registration (Google is also checked
-					// earlier in mapProfileToUser).
+					// Covers email/password registration and OIDC provisioning, and
+					// is the only allowlist gate for OIDC (Google is also checked
+					// earlier in mapProfileToUser). Throwing here reaches an OIDC
+					// user as a readable redirect back to the sign-in page.
 					assertAllowedEmailDomain(user.email);
 					const row = sqlite.query("SELECT COUNT(*) AS c FROM user").get() as {
 						c: number;
@@ -109,7 +156,12 @@ export const auth = betterAuth({
 						.query("SELECT isDisabled FROM user WHERE id = ?")
 						.get(session.userId) as { isDisabled: number } | null;
 					if (user?.isDisabled) {
+						// The OAuth callback only converts a thrown error into a
+						// redirect when the body carries a `code`; without one a
+						// disabled user would be stranded on the callback URL
+						// looking at raw JSON.
 						throw new APIError("FORBIDDEN", {
+							code: "ACCOUNT_DISABLED",
 							message: "This account is disabled",
 						});
 					}
@@ -207,7 +259,8 @@ export async function setSolarUserPassword(
 	} else {
 		await context.internalAdapter.createAccount({
 			userId,
-			providerId: "credential",
+			providerId: CREDENTIAL_PROVIDER_ID,
+			issuer: CREDENTIAL_ACCOUNT_ISSUER,
 			accountId: userId,
 			password: hashedPassword,
 		});

--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -18,18 +18,37 @@ import {
 
 export const API_KEY_HEADER = "x-api-key";
 
-/** Throws unless the email's domain is on the (optional) allowlist. */
-function assertAllowedEmailDomain(email: string): void {
+interface EmailDomainValidationError {
+	error: "EMAIL_DOMAIN_NOT_ALLOWED";
+	errorDescription: string;
+}
+
+/** Returns the browser-safe rejection details when an email violates policy. */
+function emailDomainValidationError(
+	email: unknown,
+): EmailDomainValidationError | undefined {
 	const allowed = config.allowedEmailDomains;
 	if (allowed.length === 0) return;
-	const domain = email.split("@").at(-1)?.toLowerCase();
+	const domain =
+		typeof email === "string" ? email.split("@").at(-1)?.toLowerCase() : null;
 	if (!domain || !allowed.includes(domain)) {
+		return {
+			error: "EMAIL_DOMAIN_NOT_ALLOWED",
+			errorDescription: "Email domain is not allowed",
+		};
+	}
+}
+
+/** Throws unless the email's domain is on the (optional) allowlist. */
+function assertAllowedEmailDomain(email: string): void {
+	const rejection = emailDomainValidationError(email);
+	if (rejection) {
 		// The OAuth callback turns a thrown error into a redirect only when the
 		// body carries a `code`. Without one the browser is left on the callback
 		// URL showing raw JSON instead of the sign-in page.
 		throw new APIError("FORBIDDEN", {
-			code: "EMAIL_DOMAIN_NOT_ALLOWED",
-			message: "Email domain is not allowed",
+			code: rejection.error,
+			message: rejection.errorDescription,
 		});
 	}
 }
@@ -103,6 +122,13 @@ export const auth = betterAuth({
 			: []),
 	],
 	user: {
+		// Generic OAuth invokes this before create, link, and returning sign-in.
+		// Returning structured details lets its callback preserve the readable
+		// redirect instead of converting a thrown hook error to validation_failed.
+		validateUserInfo: ({ user, source }) => {
+			if (source.oauth?.providerId !== OIDC_PROVIDER_ID) return;
+			return emailDomainValidationError(user.email);
+		},
 		additionalFields: {
 			// Admin/user roles (full enforcement + admin UI land in M4). Assigned by
 			// the server, never accepted from client input.
@@ -136,10 +162,8 @@ export const auth = betterAuth({
 			create: {
 				// First account to register on a deployment becomes the admin.
 				before: async (user) => {
-					// Covers email/password registration and OIDC provisioning, and
-					// is the only allowlist gate for OIDC (Google is also checked
-					// earlier in mapProfileToUser). Throwing here reaches an OIDC
-					// user as a readable redirect back to the sign-in page.
+					// Covers email/password registration as a final persistence-layer
+					// guard. Google and OIDC are checked earlier in their provider flows.
 					assertAllowedEmailDomain(user.email);
 					const row = sqlite.query("SELECT COUNT(*) AS c FROM user").get() as {
 						c: number;

--- a/apps/server/src/config.test.ts
+++ b/apps/server/src/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { isTruthy } from "./config";
+import { isTruthy, parseOidcConfig } from "./config";
 
 describe("environment booleans", () => {
 	test("recognizes explicit chat feature-flag values", () => {
@@ -9,5 +9,99 @@ describe("environment booleans", () => {
 		expect(isTruthy("0")).toBe(false);
 		expect(isTruthy("false")).toBe(false);
 		expect(isTruthy(undefined)).toBe(false);
+	});
+});
+
+const CREDENTIALS = {
+	OIDC_ISSUER: "https://auth.example.com",
+	OIDC_CLIENT_ID: "solar",
+	OIDC_CLIENT_SECRET: "secret",
+};
+
+describe("parseOidcConfig", () => {
+	test("is disabled until issuer and both credentials are present", () => {
+		expect(parseOidcConfig({})).toBeNull();
+		expect(
+			parseOidcConfig({ OIDC_ISSUER: CREDENTIALS.OIDC_ISSUER }),
+		).toBeNull();
+		expect(
+			parseOidcConfig({
+				OIDC_ISSUER: CREDENTIALS.OIDC_ISSUER,
+				OIDC_CLIENT_ID: "solar",
+			}),
+		).toBeNull();
+		expect(
+			parseOidcConfig({ ...CREDENTIALS, OIDC_CLIENT_SECRET: "   " }),
+		).toBeNull();
+	});
+
+	test("applies defaults", () => {
+		const oidc = parseOidcConfig(CREDENTIALS);
+		expect(oidc?.displayName).toBe("SSO");
+		expect(oidc?.scopes).toEqual(["openid", "profile", "email"]);
+		expect(oidc?.disableSignUp).toBe(false);
+		expect(oidc?.adminClaim).toBeUndefined();
+		expect(oidc?.adminValue).toBeUndefined();
+	});
+
+	test("derives the discovery URL without doubling the slash", () => {
+		expect(parseOidcConfig(CREDENTIALS)?.discoveryUrl).toBe(
+			"https://auth.example.com/.well-known/openid-configuration",
+		);
+		const trailing = parseOidcConfig({
+			...CREDENTIALS,
+			OIDC_ISSUER: "https://auth.example.com/application/o/solar/",
+		});
+		expect(trailing?.discoveryUrl).toBe(
+			"https://auth.example.com/application/o/solar/.well-known/openid-configuration",
+		);
+	});
+
+	test("keeps the issuer verbatim so the iss check can match", () => {
+		const issuer = "https://auth.example.com/application/o/solar/";
+		expect(
+			parseOidcConfig({ ...CREDENTIALS, OIDC_ISSUER: issuer })?.issuer,
+		).toBe(issuer);
+	});
+
+	test("parses scopes from either separator and always includes openid", () => {
+		expect(
+			parseOidcConfig({ ...CREDENTIALS, OIDC_SCOPES: "openid email groups" })
+				?.scopes,
+		).toEqual(["openid", "email", "groups"]);
+		expect(
+			parseOidcConfig({ ...CREDENTIALS, OIDC_SCOPES: "email, groups" })?.scopes,
+		).toEqual(["openid", "email", "groups"]);
+		expect(
+			parseOidcConfig({ ...CREDENTIALS, OIDC_SCOPES: "  " })?.scopes,
+		).toEqual(["openid", "profile", "email"]);
+	});
+
+	test("enables role mapping only when both halves are set", () => {
+		expect(
+			parseOidcConfig({ ...CREDENTIALS, OIDC_ADMIN_CLAIM: "groups" })
+				?.adminClaim,
+		).toBeUndefined();
+		expect(
+			parseOidcConfig({ ...CREDENTIALS, OIDC_ADMIN_VALUE: "solar-admins" })
+				?.adminValue,
+		).toBeUndefined();
+		const both = parseOidcConfig({
+			...CREDENTIALS,
+			OIDC_ADMIN_CLAIM: "groups",
+			OIDC_ADMIN_VALUE: "solar-admins",
+		});
+		expect(both?.adminClaim).toBe("groups");
+		expect(both?.adminValue).toBe("solar-admins");
+	});
+
+	test("reads the sign-up switch and display name", () => {
+		const oidc = parseOidcConfig({
+			...CREDENTIALS,
+			OIDC_DISABLE_SIGNUP: "yes",
+			OIDC_DISPLAY_NAME: "Authentik",
+		});
+		expect(oidc?.disableSignUp).toBe(true);
+		expect(oidc?.displayName).toBe("Authentik");
 	});
 });

--- a/apps/server/src/config.test.ts
+++ b/apps/server/src/config.test.ts
@@ -97,6 +97,19 @@ describe("parseOidcConfig", () => {
 		).toBe("http://[::1]:8080/realms/solar");
 	});
 
+	test("rejects issuers with query strings or fragments", () => {
+		for (const issuer of [
+			"https://auth.example.com/realms/solar?tenant=solar",
+			"https://auth.example.com/realms/solar#configuration",
+			"https://auth.example.com/realms/solar?",
+			"https://auth.example.com/realms/solar#",
+		]) {
+			expect(() =>
+				parseOidcConfig({ ...CREDENTIALS, OIDC_ISSUER: issuer }),
+			).toThrow(/query string or fragment/);
+		}
+	});
+
 	test("parses scopes from either separator and always includes openid", () => {
 		expect(
 			parseOidcConfig({ ...CREDENTIALS, OIDC_SCOPES: "openid email groups" })

--- a/apps/server/src/config.test.ts
+++ b/apps/server/src/config.test.ts
@@ -64,6 +64,39 @@ describe("parseOidcConfig", () => {
 		).toBe(issuer);
 	});
 
+	test("rejects cleartext public issuers and non-HTTP URL schemes", () => {
+		expect(() =>
+			parseOidcConfig({
+				...CREDENTIALS,
+				OIDC_ISSUER: "http://auth.example.com",
+			}),
+		).toThrow(/HTTPS/);
+		expect(() =>
+			parseOidcConfig({ ...CREDENTIALS, OIDC_ISSUER: "file:///tmp/oidc" }),
+		).toThrow(/HTTPS/);
+	});
+
+	test("allows cleartext issuers only on explicit loopback hosts", () => {
+		expect(
+			parseOidcConfig({
+				...CREDENTIALS,
+				OIDC_ISSUER: "http://localhost:8080/realms/solar",
+			})?.issuer,
+		).toBe("http://localhost:8080/realms/solar");
+		expect(
+			parseOidcConfig({
+				...CREDENTIALS,
+				OIDC_ISSUER: "http://127.0.0.1:8080/realms/solar",
+			})?.issuer,
+		).toBe("http://127.0.0.1:8080/realms/solar");
+		expect(
+			parseOidcConfig({
+				...CREDENTIALS,
+				OIDC_ISSUER: "http://[::1]:8080/realms/solar",
+			})?.issuer,
+		).toBe("http://[::1]:8080/realms/solar");
+	});
+
 	test("parses scopes from either separator and always includes openid", () => {
 		expect(
 			parseOidcConfig({ ...CREDENTIALS, OIDC_SCOPES: "openid email groups" })

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -1,3 +1,5 @@
+import { isSecureOidcUrl } from "./oidcUrl";
+
 /** Runtime configuration from environment variables. */
 const authBaseURL =
 	process.env.BETTER_AUTH_URL ??
@@ -49,6 +51,11 @@ export function parseOidcConfig(
 	const clientId = env.OIDC_CLIENT_ID?.trim();
 	const clientSecret = env.OIDC_CLIENT_SECRET?.trim();
 	if (!issuer || !clientId || !clientSecret) return null;
+	if (!isSecureOidcUrl(issuer)) {
+		throw new Error(
+			"OIDC_ISSUER must use HTTPS; HTTP is allowed only for localhost, 127.0.0.1, or [::1]",
+		);
+	}
 
 	const scopes = (env.OIDC_SCOPES ?? "")
 		.split(/[\s,]+/)

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -56,6 +56,10 @@ export function parseOidcConfig(
 			"OIDC_ISSUER must use HTTPS; HTTP is allowed only for localhost, 127.0.0.1, or [::1]",
 		);
 	}
+	const issuerUrl = new URL(issuer);
+	if (issuerUrl.href.includes("?") || issuerUrl.href.includes("#")) {
+		throw new Error("OIDC_ISSUER must not contain a query string or fragment");
+	}
 
 	const scopes = (env.OIDC_SCOPES ?? "")
 		.split(/[\s,]+/)

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -13,6 +13,67 @@ function isTruthy(value?: string): boolean {
 
 export { isTruthy };
 
+/** Resolved settings for the optional OpenID Connect provider. */
+export interface OidcConfig {
+	/**
+	 * Issuer exactly as configured. Passed to Better Auth as `issuer`, which
+	 * compares it byte-for-byte with the `iss` callback parameter, so a trailing
+	 * slash (Authentik) must survive untouched.
+	 */
+	issuer: string;
+	discoveryUrl: string;
+	clientId: string;
+	clientSecret: string;
+	/** Label for the sign-in button ("Continue with <name>"). */
+	displayName: string;
+	scopes: string[];
+	/** When true, only admin-created users may sign in through the IdP. */
+	disableSignUp: boolean;
+	/** Claim path holding group membership, e.g. `realm_access.roles`. */
+	adminClaim?: string;
+	/** Claim value that grants the admin role. */
+	adminValue?: string;
+}
+
+const DEFAULT_OIDC_SCOPES = ["openid", "profile", "email"];
+
+/**
+ * Reads the `OIDC_*` environment into a provider config. Returns null unless the
+ * issuer and both credentials are present; that triple is what enables OIDC,
+ * mirroring how the Google client id/secret pair enables Google.
+ */
+export function parseOidcConfig(
+	env: Record<string, string | undefined>,
+): OidcConfig | null {
+	const issuer = env.OIDC_ISSUER?.trim();
+	const clientId = env.OIDC_CLIENT_ID?.trim();
+	const clientSecret = env.OIDC_CLIENT_SECRET?.trim();
+	if (!issuer || !clientId || !clientSecret) return null;
+
+	const scopes = (env.OIDC_SCOPES ?? "")
+		.split(/[\s,]+/)
+		.map((scope) => scope.trim())
+		.filter(Boolean);
+	if (scopes.length === 0) scopes.push(...DEFAULT_OIDC_SCOPES);
+	if (!scopes.includes("openid")) scopes.unshift("openid");
+
+	// Role sync needs both halves; one without the other is a misconfiguration
+	// that `index.ts` warns about at startup.
+	const adminClaim = env.OIDC_ADMIN_CLAIM?.trim();
+	const adminValue = env.OIDC_ADMIN_VALUE?.trim();
+
+	return {
+		issuer,
+		discoveryUrl: `${issuer.replace(/\/+$/, "")}/.well-known/openid-configuration`,
+		clientId,
+		clientSecret,
+		displayName: env.OIDC_DISPLAY_NAME?.trim() || "SSO",
+		scopes,
+		disableSignUp: isTruthy(env.OIDC_DISABLE_SIGNUP),
+		...(adminClaim && adminValue ? { adminClaim, adminValue } : {}),
+	};
+}
+
 export const config = {
 	port: Number(process.env.PORT ?? 3000),
 	dbPath: process.env.DATABASE_PATH ?? "solar.db",
@@ -20,9 +81,13 @@ export const config = {
 	authBaseURL,
 	googleClientId: process.env.GOOGLE_CLIENT_ID,
 	googleClientSecret: process.env.GOOGLE_CLIENT_SECRET,
+	// Optional self-hosted OpenID Connect provider (Authentik, Keycloak,
+	// Zitadel, Authelia). Null when not configured. Unlike Google this stays
+	// enabled in airgap mode: the IdP is the operator's own, not a third party.
+	oidc: parseOidcConfig(process.env),
 	cloudflareRadarApiToken: process.env.CLOUDFLARE_RADAR_API_TOKEN,
 	// Optional comma-separated list of email domains allowed to sign up or sign
-	// in (Google and email/password). Empty means any domain is allowed.
+	// in (Google, OIDC, and email/password). Empty means any domain is allowed.
 	allowedEmailDomains: (process.env.AUTH_ALLOWED_DOMAINS ?? "")
 		.split(",")
 		.map((domain) => domain.trim().toLowerCase())

--- a/apps/server/src/db/migrate-auth.test.ts
+++ b/apps/server/src/db/migrate-auth.test.ts
@@ -1,0 +1,87 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { Database } from "bun:sqlite";
+
+const sqlite = new Database(":memory:");
+const loggedErrors: unknown[] = [];
+
+mock.module("better-auth/db/migration", () => ({
+	getMigrations: async () => ({
+		toBeCreated: [],
+		toBeAdded: [],
+		runMigrations: async () => {},
+	}),
+}));
+mock.module("../accountIssuer", () => ({
+	accountIssuerFor: (providerId: string) => `issuer:${providerId}`,
+}));
+mock.module("../auth", () => ({ auth: { options: {} } }));
+mock.module("../logger", () => {
+	const chain = {
+		withError: (error: unknown) => {
+			loggedErrors.push(error);
+			return chain;
+		},
+		withMetadata: () => chain,
+		info: () => {},
+		error: () => {},
+	};
+	return { logger: chain };
+});
+mock.module("./index", () => ({ sqlite }));
+
+const { migrateAuth } = await import("./migrate-auth");
+
+describe("Better Auth issuer migration", () => {
+	beforeEach(() => {
+		sqlite.exec("DROP TABLE IF EXISTS account; DROP TABLE IF EXISTS user;");
+		loggedErrors.length = 0;
+	});
+
+	afterAll(() => sqlite.close());
+
+	test("resumes backfilling rows left empty after the issuer column was added", async () => {
+		sqlite.exec(`
+			CREATE TABLE account (
+				id TEXT PRIMARY KEY,
+				providerId TEXT NOT NULL,
+				accountId TEXT NOT NULL,
+				issuer TEXT NOT NULL DEFAULT ''
+			);
+			INSERT INTO account (id, providerId, accountId, issuer)
+			VALUES
+				('a1', 'credential', 'u1', 'issuer:credential'),
+				('a2', 'google', 'subject-2', '');
+		`);
+
+		await migrateAuth();
+
+		expect(
+			sqlite.query("SELECT issuer FROM account WHERE id = 'a2'").get(),
+		).toEqual({ issuer: "issuer:google" });
+		expect(
+			sqlite
+				.query(
+					"SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'account_issuer_accountId_uidx'",
+				)
+				.get(),
+		).toEqual({ name: "account_issuer_accountId_uidx" });
+	});
+
+	test("fails migration when duplicate identities prevent the unique index", async () => {
+		sqlite.exec(`
+			CREATE TABLE account (
+				id TEXT PRIMARY KEY,
+				providerId TEXT NOT NULL,
+				accountId TEXT NOT NULL,
+				issuer TEXT NOT NULL
+			);
+			INSERT INTO account (id, providerId, accountId, issuer)
+			VALUES
+				('a1', 'google', 'subject-1', 'issuer:google'),
+				('a2', 'google', 'subject-1', 'issuer:google');
+		`);
+
+		await expect(migrateAuth()).rejects.toThrow(/UNIQUE constraint failed/);
+		expect(loggedErrors).toHaveLength(1);
+	});
+});

--- a/apps/server/src/db/migrate-auth.ts
+++ b/apps/server/src/db/migrate-auth.ts
@@ -4,6 +4,7 @@ import { auth } from "../auth";
 import { logger } from "../logger";
 import { sqlite } from "./index";
 
+/** Returns a table's current columns, or an empty list before it exists. */
 function columnNames(table: string): string[] {
 	const columns = sqlite.query(`PRAGMA table_info(${table})`).all() as {
 		name: string;
@@ -34,13 +35,13 @@ function ensureAccountIssuerIndex(): void {
 		logger.info(`created ${ACCOUNT_ISSUER_INDEX}`);
 	} catch (error) {
 		// Only reachable if the table already holds two rows for one external
-		// identity. Leave the server running and name the problem, since the
-		// index is a safety net rather than something existing flows depend on.
+		// identity. Authentication must not start without its identity constraint.
 		logger
 			.withError(error)
 			.error(
 				`could not create ${ACCOUNT_ISSUER_INDEX}; resolve duplicate (issuer, accountId) rows in the account table`,
 			);
+		throw error;
 	}
 }
 
@@ -61,15 +62,20 @@ function backfillAccountIssuer(): void {
 		sqlite.exec(
 			"ALTER TABLE account ADD COLUMN issuer TEXT NOT NULL DEFAULT ''",
 		);
-		const providers = sqlite
-			.query("SELECT DISTINCT providerId FROM account")
-			.all() as { providerId: string }[];
-		const update = sqlite.query(
-			"UPDATE account SET issuer = ? WHERE providerId = ?",
-		);
-		for (const { providerId } of providers) {
-			update.run(accountIssuerFor(providerId), providerId);
-		}
+	}
+
+	// Run on every startup so an interruption after ALTER TABLE cannot strand
+	// rows at the temporary empty default and break identity lookup permanently.
+	const providers = sqlite
+		.query("SELECT DISTINCT providerId FROM account WHERE issuer = ''")
+		.all() as { providerId: string }[];
+	const update = sqlite.query(
+		"UPDATE account SET issuer = ? WHERE providerId = ? AND issuer = ''",
+	);
+	for (const { providerId } of providers) {
+		update.run(accountIssuerFor(providerId), providerId);
+	}
+	if (providers.length > 0) {
 		logger
 			.withMetadata({
 				providers: providers.map((row) => row.providerId),

--- a/apps/server/src/db/migrate-auth.ts
+++ b/apps/server/src/db/migrate-auth.ts
@@ -1,7 +1,84 @@
 import { getMigrations } from "better-auth/db/migration";
+import { accountIssuerFor } from "../accountIssuer";
 import { auth } from "../auth";
 import { logger } from "../logger";
 import { sqlite } from "./index";
+
+function columnNames(table: string): string[] {
+	const columns = sqlite.query(`PRAGMA table_info(${table})`).all() as {
+		name: string;
+	}[];
+	return columns.map((column) => column.name);
+}
+
+/** Matches the index better-auth creates on a fresh 1.7 database. */
+const ACCOUNT_ISSUER_INDEX = "account_issuer_accountId_uidx";
+
+/**
+ * Recreates the `(issuer, accountId)` unique index on an upgraded database.
+ *
+ * Better Auth only emits schema changes for missing tables and columns, so once
+ * the backfill below has added the column its generator has nothing left to do
+ * and never creates this index. Without it an upgraded deployment would quietly
+ * run without the uniqueness guarantee a fresh install gets.
+ */
+function ensureAccountIssuerIndex(): void {
+	const existing = sqlite
+		.query("SELECT name FROM sqlite_master WHERE type = 'index' AND name = ?")
+		.get(ACCOUNT_ISSUER_INDEX);
+	if (existing) return;
+	try {
+		sqlite.exec(
+			`CREATE UNIQUE INDEX "${ACCOUNT_ISSUER_INDEX}" ON "account" ("issuer", "accountId")`,
+		);
+		logger.info(`created ${ACCOUNT_ISSUER_INDEX}`);
+	} catch (error) {
+		// Only reachable if the table already holds two rows for one external
+		// identity. Leave the server running and name the problem, since the
+		// index is a safety net rather than something existing flows depend on.
+		logger
+			.withError(error)
+			.error(
+				`could not create ${ACCOUNT_ISSUER_INDEX}; resolve duplicate (issuer, accountId) rows in the account table`,
+			);
+	}
+}
+
+/**
+ * Adds and backfills `account.issuer`, introduced as a required column in
+ * Better Auth 1.7 together with a unique index on `(issuer, accountId)`.
+ *
+ * Better Auth's generator cannot add a NOT NULL column to a table that already
+ * has rows, and it never backfills values, so this runs first. Without it every
+ * existing sign-in breaks.
+ */
+function backfillAccountIssuer(): void {
+	const columns = columnNames("account");
+	// No table yet: better-auth creates it complete, index included.
+	if (columns.length === 0) return;
+
+	if (!columns.includes("issuer")) {
+		sqlite.exec(
+			"ALTER TABLE account ADD COLUMN issuer TEXT NOT NULL DEFAULT ''",
+		);
+		const providers = sqlite
+			.query("SELECT DISTINCT providerId FROM account")
+			.all() as { providerId: string }[];
+		const update = sqlite.query(
+			"UPDATE account SET issuer = ? WHERE providerId = ?",
+		);
+		for (const { providerId } of providers) {
+			update.run(accountIssuerFor(providerId), providerId);
+		}
+		logger
+			.withMetadata({
+				providers: providers.map((row) => row.providerId),
+			})
+			.info("backfilled account.issuer for better-auth 1.7");
+	}
+
+	ensureAccountIssuerIndex();
+}
 
 /**
  * Runs Better Auth's own table migrations against the shared `solar.db`. Better
@@ -9,17 +86,13 @@ import { sqlite } from "./index";
  * startup so the single DB is fully provisioned.
  */
 export async function migrateAuth(): Promise<void> {
-	const columns = sqlite.query("PRAGMA table_info(user)").all() as {
-		name: string;
-	}[];
-	if (
-		columns.length > 0 &&
-		!columns.some((column) => column.name === "isDisabled")
-	) {
+	const userColumns = columnNames("user");
+	if (userColumns.length > 0 && !userColumns.includes("isDisabled")) {
 		sqlite.exec(
 			"ALTER TABLE user ADD COLUMN isDisabled INTEGER NOT NULL DEFAULT 0",
 		);
 	}
+	backfillAccountIssuer();
 	const { toBeCreated, toBeAdded, runMigrations } = await getMigrations(
 		auth.options,
 	);

--- a/apps/server/src/db/types.generated.ts
+++ b/apps/server/src/db/types.generated.ts
@@ -17,6 +17,7 @@ export interface Account {
 	createdAt: string;
 	id: string;
 	idToken: string | null;
+	issuer: string;
 	password: string | null;
 	providerId: string;
 	refreshToken: string | null;

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { getLogLevel, logger } from "./logger";
 import { config } from "./config";
 import { auth } from "./auth";
+import { OAUTH_CALLBACK_PATH, oauthCallbackPathIsRegistered } from "./oidc";
 import type {} from "./db";
 import { db, sqlite } from "./db";
 import { migrateAuth } from "./db/migrate-auth";
@@ -114,6 +115,42 @@ if (
 	logger.warn(
 		"BETTER_AUTH_SECRET is missing, short, or uses the development fallback",
 	);
+}
+
+// OIDC needs all three of issuer, client id, and client secret; a partial set
+// silently leaves sign-in unavailable, so say so instead.
+const oidcParts = [
+	process.env.OIDC_ISSUER,
+	process.env.OIDC_CLIENT_ID,
+	process.env.OIDC_CLIENT_SECRET,
+].filter((value) => Boolean(value?.trim()));
+if (oidcParts.length > 0 && oidcParts.length < 3) {
+	logger.warn(
+		"OIDC is partially configured and disabled; set OIDC_ISSUER, OIDC_CLIENT_ID, and OIDC_CLIENT_SECRET",
+	);
+}
+if (
+	Boolean(process.env.OIDC_ADMIN_CLAIM?.trim()) !==
+	Boolean(process.env.OIDC_ADMIN_VALUE?.trim())
+) {
+	logger.warn(
+		"OIDC role mapping is disabled; OIDC_ADMIN_CLAIM and OIDC_ADMIN_VALUE must both be set",
+	);
+}
+// Role sync hangs off Better Auth's OAuth callback route. If a future release
+// renames it the hook would just stop firing, freezing every admin role with
+// nothing in the log, so fail loudly here instead.
+if (config.oidc?.adminClaim) {
+	const registeredPaths = Object.values(
+		auth.api as unknown as Record<string, { path?: string }>,
+	).map((endpoint) => endpoint?.path);
+	if (!oauthCallbackPathIsRegistered(registeredPaths)) {
+		logger
+			.withMetadata({ expected: OAUTH_CALLBACK_PATH })
+			.error(
+				"OIDC role mapping will not run: better-auth no longer registers the expected OAuth callback route",
+			);
+	}
 }
 
 // Provision the single solar.db: our app migrations + Better Auth's own tables.

--- a/apps/server/src/oidc.test.ts
+++ b/apps/server/src/oidc.test.ts
@@ -1,0 +1,380 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type { OidcConfig } from "./config";
+
+let oidcConfig: OidcConfig | null = null;
+let userRow: { role: string; isDisabled: number } | null = null;
+let activeAdmins = 2;
+const roleWrites: { userId: string; role: string }[] = [];
+
+mock.module("./config", () => ({
+	config: {
+		get oidc() {
+			return oidcConfig;
+		},
+	},
+}));
+mock.module("./db", () => ({
+	db: {},
+	sqlite: { query: () => ({ get: () => userRow }) },
+}));
+mock.module("./userRoles", () => ({
+	countActiveAdmins: () => activeAdmins,
+	applyUserRole: async (userId: string, role: string) => {
+		roleWrites.push({ userId, role });
+	},
+}));
+const noop = () => {};
+const chain = {
+	withMetadata: () => chain,
+	withError: () => chain,
+	info: noop,
+	warn: noop,
+	error: noop,
+};
+mock.module("./logger", () => ({ logger: chain }));
+
+const {
+	buildOidcProviderConfig,
+	claimContains,
+	decodeJwtPayload,
+	getClaim,
+	oauthCallbackPathIsRegistered,
+	OIDC_PROVIDER_ID,
+	resetOidcDiscoveryCache,
+	roleFromClaims,
+	syncOidcRole,
+} = await import("./oidc");
+
+function baseConfig(overrides: Partial<OidcConfig> = {}): OidcConfig {
+	return {
+		issuer: "https://auth.example.com/",
+		discoveryUrl: "https://auth.example.com/.well-known/openid-configuration",
+		clientId: "solar",
+		clientSecret: "secret",
+		displayName: "Keycloak",
+		scopes: ["openid", "profile", "email"],
+		disableSignUp: false,
+		adminClaim: "groups",
+		adminValue: "solar-admins",
+		...overrides,
+	};
+}
+
+function idToken(claims: Record<string, unknown>): string {
+	return `header.${Buffer.from(JSON.stringify(claims)).toString("base64url")}.signature`;
+}
+
+function contextWith(account: Record<string, unknown> | null) {
+	return {
+		internalAdapter: {
+			findAccounts: async () =>
+				account ? [account as never] : ([] as never[]),
+		},
+	};
+}
+
+describe("decodeJwtPayload", () => {
+	test("reads the claims of a well-formed token", () => {
+		expect(decodeJwtPayload(idToken({ sub: "1", groups: ["a"] }))).toEqual({
+			sub: "1",
+			groups: ["a"],
+		});
+	});
+
+	test("returns null for anything it cannot read", () => {
+		expect(decodeJwtPayload("not-a-jwt")).toBeNull();
+		expect(decodeJwtPayload("header..signature")).toBeNull();
+		expect(
+			decodeJwtPayload(
+				`header.${Buffer.from("[1,2]").toString("base64url")}.sig`,
+			),
+		).toBeNull();
+	});
+});
+
+describe("getClaim", () => {
+	test("prefers a literal key so colons and dots in names survive", () => {
+		const zitadel = "urn:zitadel:iam:org:project:roles";
+		expect(getClaim({ [zitadel]: { admin: {} } }, zitadel)).toEqual({
+			admin: {},
+		});
+		expect(getClaim({ "a.b": "literal", a: { b: "nested" } }, "a.b")).toBe(
+			"literal",
+		);
+	});
+
+	test("walks a dotted path", () => {
+		expect(
+			getClaim(
+				{ realm_access: { roles: ["solar-admins"] } },
+				"realm_access.roles",
+			),
+		).toEqual(["solar-admins"]);
+	});
+
+	test("is undefined when the path is missing", () => {
+		expect(getClaim({}, "groups")).toBeUndefined();
+		expect(
+			getClaim({ realm_access: null }, "realm_access.roles"),
+		).toBeUndefined();
+	});
+});
+
+describe("claimContains", () => {
+	test("matches an array of groups", () => {
+		expect(claimContains(["users", "solar-admins"], "solar-admins")).toBe(true);
+		expect(claimContains(["users"], "solar-admins")).toBe(false);
+	});
+
+	test("matches an object keyed by role name", () => {
+		expect(
+			claimContains({ "solar-admins": { org: "1" } }, "solar-admins"),
+		).toBe(true);
+		expect(claimContains({ other: {} }, "solar-admins")).toBe(false);
+	});
+
+	test("matches a single or delimited string", () => {
+		expect(claimContains("solar-admins", "solar-admins")).toBe(true);
+		expect(claimContains("users solar-admins", "solar-admins")).toBe(true);
+		expect(claimContains("users,solar-admins", "solar-admins")).toBe(true);
+		expect(claimContains("solar-admins-extra", "solar-admins")).toBe(false);
+	});
+
+	test("is case-sensitive and rejects other shapes", () => {
+		expect(claimContains(["Solar-Admins"], "solar-admins")).toBe(false);
+		expect(claimContains(undefined, "solar-admins")).toBe(false);
+		expect(claimContains(42, "solar-admins")).toBe(false);
+	});
+});
+
+describe("roleFromClaims", () => {
+	const options = { adminClaim: "groups", adminValue: "solar-admins" };
+
+	test("grants admin when the claim carries the value", () => {
+		expect(roleFromClaims({ groups: ["solar-admins"] }, options)).toBe("admin");
+	});
+
+	test("treats a missing claim as a plain user", () => {
+		expect(roleFromClaims({}, options)).toBe("user");
+		expect(roleFromClaims({ groups: [] }, options)).toBe("user");
+	});
+});
+
+describe("buildOidcProviderConfig", () => {
+	test("enables PKCE and pins the account issuer without mapping the profile", () => {
+		const built = buildOidcProviderConfig(baseConfig());
+		expect(built.providerId).toBe(OIDC_PROVIDER_ID);
+		expect(built.pkce).toBe(true);
+		// Pinned so a discovery outage cannot abort provider initialization,
+		// and so account.issuer stays predictable for the 1.7 backfill.
+		expect(built.accountIssuer).toBe("https://auth.example.com/");
+		expect(built.disableSignUp).toBe(false);
+		expect(built).not.toHaveProperty("mapProfileToUser");
+		expect(built).not.toHaveProperty("overrideUserInfo");
+	});
+});
+
+describe("oauthCallbackPathIsRegistered", () => {
+	test("recognises the route the role-sync hook matches", () => {
+		expect(oauthCallbackPathIsRegistered(["/callback/:id", "/ok"])).toBe(true);
+	});
+
+	test("reports a route that upstream has renamed", () => {
+		// The 1.6 path. Returning false here is what makes the next rename loud
+		// instead of silently freezing admin roles.
+		expect(
+			oauthCallbackPathIsRegistered(["/oauth2/callback/:providerId"]),
+		).toBe(false);
+	});
+});
+
+describe("syncOidcRole", () => {
+	const originalFetch = globalThis.fetch;
+
+	beforeEach(() => {
+		oidcConfig = baseConfig();
+		userRow = { role: "user", isDisabled: 0 };
+		activeAdmins = 2;
+		roleWrites.length = 0;
+		globalThis.fetch = originalFetch;
+		resetOidcDiscoveryCache();
+	});
+
+	test("promotes a user whose token carries the admin group", async () => {
+		await syncOidcRole(
+			"u1",
+			contextWith({
+				providerId: OIDC_PROVIDER_ID,
+				idToken: idToken({ groups: ["solar-admins"] }),
+			}),
+		);
+
+		expect(roleWrites).toEqual([{ userId: "u1", role: "admin" }]);
+	});
+
+	test("demotes an admin who lost the group", async () => {
+		userRow = { role: "admin", isDisabled: 0 };
+		await syncOidcRole(
+			"u1",
+			contextWith({
+				providerId: OIDC_PROVIDER_ID,
+				idToken: idToken({ groups: ["users"] }),
+			}),
+		);
+
+		expect(roleWrites).toEqual([{ userId: "u1", role: "user" }]);
+	});
+
+	test("keeps the last active admin", async () => {
+		userRow = { role: "admin", isDisabled: 0 };
+		activeAdmins = 1;
+		await syncOidcRole(
+			"u1",
+			contextWith({
+				providerId: OIDC_PROVIDER_ID,
+				idToken: idToken({ groups: ["users"] }),
+			}),
+		);
+
+		expect(roleWrites).toEqual([]);
+	});
+
+	test("writes nothing when the role already matches", async () => {
+		userRow = { role: "admin", isDisabled: 0 };
+		await syncOidcRole(
+			"u1",
+			contextWith({
+				providerId: OIDC_PROVIDER_ID,
+				idToken: idToken({ groups: ["solar-admins"] }),
+			}),
+		);
+
+		expect(roleWrites).toEqual([]);
+	});
+
+	test("does nothing when role mapping is not configured", async () => {
+		oidcConfig = baseConfig({ adminClaim: undefined, adminValue: undefined });
+		await syncOidcRole(
+			"u1",
+			contextWith({
+				providerId: OIDC_PROVIDER_ID,
+				idToken: idToken({ groups: ["solar-admins"] }),
+			}),
+		);
+
+		expect(roleWrites).toEqual([]);
+	});
+
+	test("ignores users with no OIDC account", async () => {
+		await syncOidcRole("u1", contextWith({ providerId: "google" }));
+
+		expect(roleWrites).toEqual([]);
+	});
+
+	test("falls back to userinfo when the claim is absent from the token", async () => {
+		const seen: string[] = [];
+		globalThis.fetch = (async (
+			input: string | URL | Request,
+			init?: RequestInit,
+		) => {
+			const url = String(input);
+			seen.push(url);
+			if (url.endsWith("/.well-known/openid-configuration"))
+				return Response.json({
+					userinfo_endpoint: "https://auth.example.com/userinfo",
+				});
+			expect((init?.headers as Record<string, string>).Authorization).toBe(
+				"Bearer at",
+			);
+			return Response.json({ groups: ["solar-admins"] });
+		}) as unknown as typeof fetch;
+
+		await syncOidcRole(
+			"u1",
+			contextWith({
+				providerId: OIDC_PROVIDER_ID,
+				idToken: idToken({ sub: "1" }),
+				accessToken: "at",
+			}),
+		);
+
+		expect(seen).toEqual([
+			"https://auth.example.com/.well-known/openid-configuration",
+			"https://auth.example.com/userinfo",
+		]);
+		expect(roleWrites).toEqual([{ userId: "u1", role: "admin" }]);
+	});
+
+	test("demotes when userinfo answers without the group", async () => {
+		userRow = { role: "admin", isDisabled: 0 };
+		globalThis.fetch = (async (input: string | URL | Request) =>
+			String(input).endsWith("/.well-known/openid-configuration")
+				? Response.json({
+						userinfo_endpoint: "https://auth.example.com/userinfo",
+					})
+				: Response.json({ groups: ["users"] })) as unknown as typeof fetch;
+
+		await syncOidcRole(
+			"u1",
+			contextWith({
+				providerId: OIDC_PROVIDER_ID,
+				idToken: idToken({ sub: "1" }),
+				accessToken: "at",
+			}),
+		);
+
+		expect(roleWrites).toEqual([{ userId: "u1", role: "user" }]);
+	});
+
+	test("does not demote when the userinfo lookup cannot complete", async () => {
+		userRow = { role: "admin", isDisabled: 0 };
+		globalThis.fetch = (async () => {
+			throw new Error("unreachable");
+		}) as unknown as typeof fetch;
+
+		await syncOidcRole(
+			"u1",
+			contextWith({
+				providerId: OIDC_PROVIDER_ID,
+				idToken: idToken({ sub: "1" }),
+				accessToken: "at",
+			}),
+		);
+
+		expect(roleWrites).toEqual([]);
+	});
+
+	test("does not demote when userinfo returns an error status", async () => {
+		userRow = { role: "admin", isDisabled: 0 };
+		globalThis.fetch = (async (input: string | URL | Request) =>
+			String(input).endsWith("/.well-known/openid-configuration")
+				? Response.json({
+						userinfo_endpoint: "https://auth.example.com/userinfo",
+					})
+				: new Response("nope", { status: 503 })) as unknown as typeof fetch;
+
+		await syncOidcRole(
+			"u1",
+			contextWith({
+				providerId: OIDC_PROVIDER_ID,
+				idToken: idToken({ sub: "1" }),
+				accessToken: "at",
+			}),
+		);
+
+		expect(roleWrites).toEqual([]);
+	});
+
+	test("swallows adapter failures so the sign-in redirect survives", async () => {
+		const context = {
+			internalAdapter: {
+				findAccounts: async () => {
+					throw new Error("database is gone");
+				},
+			},
+		};
+
+		expect(await syncOidcRole("u1", context)).toBeUndefined();
+		expect(roleWrites).toEqual([]);
+	});
+});

--- a/apps/server/src/oidc.test.ts
+++ b/apps/server/src/oidc.test.ts
@@ -65,10 +65,22 @@ function idToken(claims: Record<string, unknown>): string {
 }
 
 function contextWith(account: Record<string, unknown> | null) {
+	const normalized =
+		account?.providerId === OIDC_PROVIDER_ID
+			? { issuer: baseConfig().issuer, ...account }
+			: account;
 	return {
 		internalAdapter: {
 			findAccounts: async () =>
-				account ? [account as never] : ([] as never[]),
+				normalized ? [normalized as never] : ([] as never[]),
+		},
+	};
+}
+
+function contextWithAccounts(accounts: Record<string, unknown>[]) {
+	return {
+		internalAdapter: {
+			findAccounts: async () => accounts as never[],
 		},
 	};
 }
@@ -273,12 +285,14 @@ describe("syncOidcRole", () => {
 
 	test("falls back to userinfo when the claim is absent from the token", async () => {
 		const seen: string[] = [];
+		const requestOptions: (RequestInit | undefined)[] = [];
 		globalThis.fetch = (async (
 			input: string | URL | Request,
 			init?: RequestInit,
 		) => {
 			const url = String(input);
 			seen.push(url);
+			requestOptions.push(init);
 			if (url.endsWith("/.well-known/openid-configuration"))
 				return Response.json({
 					userinfo_endpoint: "https://auth.example.com/userinfo",
@@ -302,7 +316,61 @@ describe("syncOidcRole", () => {
 			"https://auth.example.com/.well-known/openid-configuration",
 			"https://auth.example.com/userinfo",
 		]);
+		expect(requestOptions).toHaveLength(2);
+		for (const options of requestOptions) {
+			expect(options?.redirect).toBe("error");
+			expect(options?.signal).toBeInstanceOf(AbortSignal);
+		}
 		expect(roleWrites).toEqual([{ userId: "u1", role: "admin" }]);
+	});
+
+	test.each([
+		"http://auth.example.com/userinfo",
+		"file:///tmp/userinfo",
+		"not a URL",
+	])(
+		"does not send an access token to an unsafe userinfo URL: %s",
+		async (endpoint) => {
+			const seen: string[] = [];
+			globalThis.fetch = (async (input: string | URL | Request) => {
+				seen.push(String(input));
+				return Response.json({ userinfo_endpoint: endpoint });
+			}) as unknown as typeof fetch;
+
+			await syncOidcRole(
+				"u1",
+				contextWith({
+					providerId: OIDC_PROVIDER_ID,
+					idToken: idToken({ sub: "1" }),
+					accessToken: "must-not-leak",
+				}),
+			);
+
+			expect(seen).toEqual([
+				"https://auth.example.com/.well-known/openid-configuration",
+			]);
+			expect(roleWrites).toEqual([]);
+		},
+	);
+
+	test("uses only the account belonging to the configured issuer", async () => {
+		await syncOidcRole(
+			"u1",
+			contextWithAccounts([
+				{
+					providerId: OIDC_PROVIDER_ID,
+					issuer: "https://old-idp.example.com/",
+					idToken: idToken({ groups: ["solar-admins"] }),
+				},
+				{
+					providerId: OIDC_PROVIDER_ID,
+					issuer: baseConfig().issuer,
+					idToken: idToken({ groups: ["users"] }),
+				},
+			]),
+		);
+
+		expect(roleWrites).toEqual([]);
 	});
 
 	test("demotes when userinfo answers without the group", async () => {

--- a/apps/server/src/oidc.ts
+++ b/apps/server/src/oidc.ts
@@ -53,9 +53,9 @@ export interface OidcProviderConfig {
  * Deliberately no `mapProfileToUser`: fields it returns are filtered against
  * the user schema, and `role` is `input: false`, so a role mapped there would
  * be silently dropped. Role assignment happens in `syncOidcRole` instead. The
- * email-domain allowlist is enforced by the `user.create.before` database hook,
- * whose thrown `APIError` reaches the browser as a readable redirect, unlike a
- * throw from `mapProfileToUser` (which the callback surfaces as raw JSON).
+ * email-domain allowlist is enforced by `user.validateUserInfo` before create,
+ * link, or sign-in; its structured rejection reaches the browser as a readable
+ * redirect, unlike a throw from `mapProfileToUser` (surfaced as raw JSON).
  */
 export function buildOidcProviderConfig(oidc: OidcConfig): OidcProviderConfig {
 	return {

--- a/apps/server/src/oidc.ts
+++ b/apps/server/src/oidc.ts
@@ -1,0 +1,301 @@
+import { config, type OidcConfig } from "./config";
+import { sqlite } from "./db";
+import { logger } from "./logger";
+import { applyUserRole, countActiveAdmins, type UserRole } from "./userRoles";
+
+/**
+ * Provider id for the single configurable OpenID Connect provider. It appears
+ * in the `account.providerId` column, in `accountLinking.trustedProviders`, and
+ * in the callback URL registered at the IdP:
+ * `${BETTER_AUTH_URL}/api/auth/callback/oidc`.
+ */
+export const OIDC_PROVIDER_ID = "oidc";
+
+/**
+ * Better Auth's shared OAuth callback route, as a route pattern rather than a
+ * concrete URL. The role-sync hook matches on it, and a rename upstream would
+ * otherwise make that hook silently stop firing, so `assertOAuthCallbackPath`
+ * checks it against the registered routes at startup.
+ */
+export const OAUTH_CALLBACK_PATH = "/callback/:id";
+
+/**
+ * Whether Better Auth still registers the callback route the role-sync hook
+ * matches on.
+ *
+ * Upgrading from 1.6 to 1.7 moved this route and renamed its parameter, which
+ * would have turned the hook into a silent no-op that froze admin roles with
+ * nothing in the log. Checking at startup makes the next such rename loud.
+ */
+export function oauthCallbackPathIsRegistered(
+	registeredPaths: readonly (string | undefined)[],
+): boolean {
+	return registeredPaths.includes(OAUTH_CALLBACK_PATH);
+}
+
+/** Better Auth's `GenericOAuthConfig` subset this app supplies. */
+export interface OidcProviderConfig {
+	providerId: string;
+	discoveryUrl: string;
+	accountIssuer: string;
+	clientId: string;
+	clientSecret: string;
+	scopes: string[];
+	pkce: boolean;
+	disableSignUp: boolean;
+}
+
+/**
+ * Builds the generic-OAuth provider entry.
+ *
+ * Deliberately no `mapProfileToUser`: fields it returns are filtered against
+ * the user schema, and `role` is `input: false`, so a role mapped there would
+ * be silently dropped. Role assignment happens in `syncOidcRole` instead. The
+ * email-domain allowlist is enforced by the `user.create.before` database hook,
+ * whose thrown `APIError` reaches the browser as a readable redirect, unlike a
+ * throw from `mapProfileToUser` (which the callback surfaces as raw JSON).
+ */
+export function buildOidcProviderConfig(oidc: OidcConfig): OidcProviderConfig {
+	return {
+		providerId: OIDC_PROVIDER_ID,
+		discoveryUrl: oidc.discoveryUrl,
+		// Names the account namespace stored in `account.issuer`. Setting it
+		// explicitly also keeps startup resilient: without it, Better Auth
+		// aborts provider initialization when the discovery document cannot be
+		// fetched, so an IdP that is down or still booting alongside Solar would
+		// take the whole server with it. ID-token validation still uses the
+		// issuer and JWKS from discovery, so pinning this costs no verification.
+		accountIssuer: oidc.issuer,
+		clientId: oidc.clientId,
+		clientSecret: oidc.clientSecret,
+		scopes: oidc.scopes,
+		// On by default since 1.7; kept explicit because it is a security
+		// property of this flow rather than an incidental default.
+		pkce: true,
+		disableSignUp: oidc.disableSignUp,
+	};
+}
+
+/**
+ * Decodes a JWT payload without verifying its signature.
+ *
+ * Safe here because the token never arrives from the browser: it is fetched by
+ * the server over TLS in the back-channel code exchange (client secret + PKCE),
+ * which is the trust anchor, and then read back from the `account` row we wrote.
+ */
+export function decodeJwtPayload(
+	token: string,
+): Record<string, unknown> | null {
+	try {
+		const segment = token.split(".")[1];
+		if (!segment) return null;
+		const payload: unknown = JSON.parse(
+			Buffer.from(segment, "base64url").toString("utf8"),
+		);
+		if (typeof payload !== "object" || payload === null) return null;
+		if (Array.isArray(payload)) return null;
+		return payload as Record<string, unknown>;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Reads a claim by name, falling back to a dotted path.
+ *
+ * The literal-key lookup comes first so claim names containing dots or colons
+ * (Zitadel's `urn:zitadel:iam:org:project:roles`) work, while Keycloak's nested
+ * `realm_access.roles` resolves through the path walk.
+ */
+export function getClaim(
+	payload: Record<string, unknown>,
+	path: string,
+): unknown {
+	if (Object.hasOwn(payload, path)) return payload[path];
+	let current: unknown = payload;
+	for (const segment of path.split(".")) {
+		if (typeof current !== "object" || current === null) return undefined;
+		if (!Object.hasOwn(current, segment)) return undefined;
+		current = (current as Record<string, unknown>)[segment];
+	}
+	return current;
+}
+
+/**
+ * Whether a claim value carries `target`, across the shapes the supported IdPs
+ * emit: an array of groups (Authentik, Keycloak), an object keyed by role name
+ * (Zitadel), or a single or space/comma-separated string. Case-sensitive.
+ */
+export function claimContains(value: unknown, target: string): boolean {
+	if (Array.isArray(value)) return value.some((entry) => entry === target);
+	if (typeof value === "string") {
+		if (value === target) return true;
+		return value
+			.split(/[\s,]+/)
+			.filter(Boolean)
+			.includes(target);
+	}
+	if (typeof value === "object" && value !== null)
+		return Object.hasOwn(value, target);
+	return false;
+}
+
+/** The role these claims grant. A missing claim means the user is not an admin. */
+export function roleFromClaims(
+	payload: Record<string, unknown>,
+	options: { adminClaim: string; adminValue: string },
+): UserRole {
+	return claimContains(
+		getClaim(payload, options.adminClaim),
+		options.adminValue,
+	)
+		? "admin"
+		: "user";
+}
+
+let userInfoEndpoint: Promise<string | null> | null = null;
+
+/** Resets the memoized discovery lookup. Test seam. */
+export function resetOidcDiscoveryCache(): void {
+	userInfoEndpoint = null;
+}
+
+async function fetchUserInfoEndpoint(
+	discoveryUrl: string,
+): Promise<string | null> {
+	const response = await fetch(discoveryUrl);
+	if (!response.ok) return null;
+	const document = (await response.json()) as { userinfo_endpoint?: unknown };
+	return typeof document.userinfo_endpoint === "string"
+		? document.userinfo_endpoint
+		: null;
+}
+
+async function getUserInfoEndpoint(
+	discoveryUrl: string,
+): Promise<string | null> {
+	userInfoEndpoint ??= fetchUserInfoEndpoint(discoveryUrl).catch(() => null);
+	const endpoint = await userInfoEndpoint;
+	// Do not cache a failure: the IdP may simply have been unreachable.
+	if (!endpoint) userInfoEndpoint = null;
+	return endpoint;
+}
+
+interface OidcAccount {
+	providerId: string;
+	idToken?: string | null;
+	accessToken?: string | null;
+}
+
+/** The slice of Better Auth's request context `syncOidcRole` needs. */
+export interface OidcAuthContext {
+	internalAdapter: {
+		findAccounts(userId: string): Promise<OidcAccount[]>;
+	};
+}
+
+/**
+ * Claims for this login: the ID token, falling back to the userinfo endpoint
+ * when the configured claim is absent there (Authelia, and Keycloak mappers
+ * with "Add to ID token" off).
+ *
+ * Returns null only when nothing could be read, which must not be confused
+ * with "the claim is genuinely absent" — the caller skips the sync rather than
+ * demoting a user because the IdP was briefly unreachable.
+ */
+async function resolveClaims(
+	account: OidcAccount,
+	oidc: OidcConfig & { adminClaim: string },
+): Promise<Record<string, unknown> | null> {
+	const idTokenClaims = account.idToken
+		? decodeJwtPayload(account.idToken)
+		: null;
+	if (idTokenClaims && getClaim(idTokenClaims, oidc.adminClaim) !== undefined)
+		return idTokenClaims;
+
+	// The claim is not in the ID token. Ask the userinfo endpoint before
+	// concluding the user has no groups. Without an access token there is
+	// nothing else to consult, so the ID token stands.
+	if (!account.accessToken) return idTokenClaims;
+
+	// From here a lookup that cannot complete returns null rather than the
+	// claimless ID token: "we could not check" must not read as "the user is
+	// not an admin", or an unreachable IdP would demote every admin who signs
+	// in during the outage.
+	const endpoint = await getUserInfoEndpoint(oidc.discoveryUrl);
+	if (!endpoint) return null;
+	try {
+		const response = await fetch(endpoint, {
+			headers: { Authorization: `Bearer ${account.accessToken}` },
+		});
+		if (!response.ok) return null;
+		const profile: unknown = await response.json();
+		if (typeof profile !== "object" || profile === null) return null;
+		if (Array.isArray(profile)) return null;
+		return profile as Record<string, unknown>;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Re-applies the admin role from the IdP's group claim after an OIDC sign-in,
+ * so removing someone from the group at the IdP demotes them on next login.
+ *
+ * No-op unless both `OIDC_ADMIN_CLAIM` and `OIDC_ADMIN_VALUE` are set. Never
+ * throws: this runs in an `after` hook where an exception would replace the
+ * browser's success redirect with an error.
+ */
+export async function syncOidcRole(
+	userId: string,
+	context: OidcAuthContext,
+): Promise<void> {
+	const oidc = config.oidc;
+	if (!oidc?.adminClaim || !oidc.adminValue) return;
+	try {
+		const accounts = await context.internalAdapter.findAccounts(userId);
+		const account = accounts.find(
+			(entry) => entry.providerId === OIDC_PROVIDER_ID,
+		);
+		if (!account) return;
+
+		const claims = await resolveClaims(
+			account,
+			oidc as OidcConfig & { adminClaim: string },
+		);
+		if (!claims) {
+			logger
+				.withMetadata({ userId })
+				.warn("oidc role sync skipped: no claims available");
+			return;
+		}
+
+		const desired = roleFromClaims(claims, {
+			adminClaim: oidc.adminClaim,
+			adminValue: oidc.adminValue,
+		});
+		const current = sqlite
+			.query("SELECT role, isDisabled FROM user WHERE id = ?")
+			.get(userId) as { role: string; isDisabled: number } | null;
+		if (!current || current.role === desired) return;
+
+		if (
+			desired === "user" &&
+			current.role === "admin" &&
+			!current.isDisabled &&
+			countActiveAdmins() <= 1
+		) {
+			logger
+				.withMetadata({ userId })
+				.warn("oidc role sync kept the last active admin");
+			return;
+		}
+
+		await applyUserRole(userId, desired);
+		logger
+			.withMetadata({ userId, role: desired })
+			.info("oidc role sync applied");
+	} catch (error) {
+		logger.withError(error).error("oidc role sync failed");
+	}
+}

--- a/apps/server/src/oidc.ts
+++ b/apps/server/src/oidc.ts
@@ -1,6 +1,7 @@
 import { config, type OidcConfig } from "./config";
 import { sqlite } from "./db";
 import { logger } from "./logger";
+import { isSecureOidcUrl } from "./oidcUrl";
 import { applyUserRole, countActiveAdmins, type UserRole } from "./userRoles";
 
 /**
@@ -18,6 +19,7 @@ export const OIDC_PROVIDER_ID = "oidc";
  * checks it against the registered routes at startup.
  */
 export const OAUTH_CALLBACK_PATH = "/callback/:id";
+const OIDC_FETCH_TIMEOUT_MS = 10_000;
 
 /**
  * Whether Better Auth still registers the callback route the role-sync hook
@@ -160,17 +162,25 @@ export function resetOidcDiscoveryCache(): void {
 	userInfoEndpoint = null;
 }
 
+/** Fetches and validates the discovery document's userinfo endpoint. */
 async function fetchUserInfoEndpoint(
 	discoveryUrl: string,
 ): Promise<string | null> {
-	const response = await fetch(discoveryUrl);
+	const response = await fetch(discoveryUrl, {
+		redirect: "error",
+		signal: AbortSignal.timeout(OIDC_FETCH_TIMEOUT_MS),
+	});
 	if (!response.ok) return null;
 	const document = (await response.json()) as { userinfo_endpoint?: unknown };
-	return typeof document.userinfo_endpoint === "string"
-		? document.userinfo_endpoint
-		: null;
+	if (
+		typeof document.userinfo_endpoint !== "string" ||
+		!isSecureOidcUrl(document.userinfo_endpoint)
+	)
+		return null;
+	return new URL(document.userinfo_endpoint).toString();
 }
 
+/** Memoizes successful discovery while retrying transient failures. */
 async function getUserInfoEndpoint(
 	discoveryUrl: string,
 ): Promise<string | null> {
@@ -183,6 +193,7 @@ async function getUserInfoEndpoint(
 
 interface OidcAccount {
 	providerId: string;
+	issuer: string;
 	idToken?: string | null;
 	accessToken?: string | null;
 }
@@ -227,6 +238,8 @@ async function resolveClaims(
 	try {
 		const response = await fetch(endpoint, {
 			headers: { Authorization: `Bearer ${account.accessToken}` },
+			redirect: "error",
+			signal: AbortSignal.timeout(OIDC_FETCH_TIMEOUT_MS),
 		});
 		if (!response.ok) return null;
 		const profile: unknown = await response.json();
@@ -255,7 +268,8 @@ export async function syncOidcRole(
 	try {
 		const accounts = await context.internalAdapter.findAccounts(userId);
 		const account = accounts.find(
-			(entry) => entry.providerId === OIDC_PROVIDER_ID,
+			(entry) =>
+				entry.providerId === OIDC_PROVIDER_ID && entry.issuer === oidc.issuer,
 		);
 		if (!account) return;
 

--- a/apps/server/src/oidcUrl.ts
+++ b/apps/server/src/oidcUrl.ts
@@ -1,0 +1,14 @@
+const OIDC_HTTP_LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]"]);
+
+/** Whether an OIDC endpoint uses TLS or an explicit local loopback exception. */
+export function isSecureOidcUrl(value: string): boolean {
+	try {
+		const url = new URL(value);
+		return (
+			url.protocol === "https:" ||
+			(url.protocol === "http:" && OIDC_HTTP_LOOPBACK_HOSTS.has(url.hostname))
+		);
+	} catch {
+		return false;
+	}
+}

--- a/apps/server/src/trpc/router.ts
+++ b/apps/server/src/trpc/router.ts
@@ -36,6 +36,7 @@ import {
 	setUserDefault,
 	setUserDefaultPreset,
 } from "../chat/catalog";
+import { applyUserRole, countActiveAdmins } from "../userRoles";
 import type { TrpcContext } from "./context";
 import { getLogLevel, setLogLevel, type SolarLogLevel } from "../logger";
 import { testMcpServer } from "../chat/mcp";
@@ -1201,28 +1202,15 @@ const adminRouter = router({
 			if (
 				target.role === "admin" &&
 				input.role === "user" &&
-				!target.isDisabled
+				!target.isDisabled &&
+				countActiveAdmins() <= 1
 			) {
-				const admins = sqlite
-					.query(
-						"SELECT COUNT(*) AS count FROM user WHERE role = 'admin' AND isDisabled = 0",
-					)
-					.get() as { count: number };
-				if (admins.count <= 1) {
-					throw new TRPCError({
-						code: "BAD_REQUEST",
-						message: "At least one active admin is required",
-					});
-				}
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: "At least one active admin is required",
+				});
 			}
-			sqlite
-				.query("UPDATE user SET role = ? WHERE id = ?")
-				.run(input.role, input.userId);
-			if (input.role === "user")
-				await db
-					.deleteFrom("apikey")
-					.where("referenceId", "=", input.userId)
-					.execute();
+			await applyUserRole(input.userId, input.role);
 		}),
 
 	listApiKeys: adminProcedure.query(({ ctx }) =>
@@ -1288,18 +1276,16 @@ const adminRouter = router({
 				.query("SELECT role, isDisabled FROM user WHERE id = ?")
 				.get(input.userId) as { role: string; isDisabled: number } | null;
 			if (!target) throw new TRPCError({ code: "NOT_FOUND" });
-			if (input.isDisabled && target.role === "admin" && !target.isDisabled) {
-				const admins = sqlite
-					.query(
-						"SELECT COUNT(*) AS count FROM user WHERE role = 'admin' AND isDisabled = 0",
-					)
-					.get() as { count: number };
-				if (admins.count <= 1) {
-					throw new TRPCError({
-						code: "BAD_REQUEST",
-						message: "At least one active admin is required",
-					});
-				}
+			if (
+				input.isDisabled &&
+				target.role === "admin" &&
+				!target.isDisabled &&
+				countActiveAdmins() <= 1
+			) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: "At least one active admin is required",
+				});
 			}
 			sqlite
 				.query("UPDATE user SET isDisabled = ? WHERE id = ?")
@@ -2141,6 +2127,10 @@ export const appRouter = router({
 		google: Boolean(
 			!config.airgapMode && config.googleClientId && config.googleClientSecret,
 		),
+		// Only the button label. The issuer and client id stay server-side; this
+		// query is unauthenticated. OIDC is not disabled by airgap mode because a
+		// self-hosted IdP is the operator's own service, not a third party.
+		oidc: config.oidc ? { displayName: config.oidc.displayName } : null,
 		airgap: config.airgapMode,
 	})),
 

--- a/apps/server/src/userRoles.test.ts
+++ b/apps/server/src/userRoles.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const roleUpdates: unknown[][] = [];
+const keyDeletes: string[] = [];
+
+mock.module("./db", () => ({
+	sqlite: {
+		query: (sql: string) => ({
+			run: (...args: unknown[]) => {
+				roleUpdates.push([sql, ...args]);
+			},
+			get: () => ({ count: 2 }),
+		}),
+	},
+	db: {
+		deleteFrom: () => ({
+			where: (_column: string, _op: string, value: string) => ({
+				execute: async () => {
+					keyDeletes.push(value);
+				},
+			}),
+		}),
+	},
+}));
+
+const { applyUserRole, countActiveAdmins } = await import("./userRoles");
+
+beforeEach(() => {
+	roleUpdates.length = 0;
+	keyDeletes.length = 0;
+});
+
+describe("applyUserRole", () => {
+	test("revokes API keys when demoting, since only admins may use them", async () => {
+		await applyUserRole("u1", "user");
+
+		expect(roleUpdates).toEqual([
+			["UPDATE user SET role = ? WHERE id = ?", "user", "u1"],
+		]);
+		expect(keyDeletes).toEqual(["u1"]);
+	});
+
+	test("keeps API keys when promoting", async () => {
+		await applyUserRole("u1", "admin");
+
+		expect(roleUpdates).toEqual([
+			["UPDATE user SET role = ? WHERE id = ?", "admin", "u1"],
+		]);
+		expect(keyDeletes).toEqual([]);
+	});
+});
+
+describe("countActiveAdmins", () => {
+	test("reads the count of enabled admins", () => {
+		expect(countActiveAdmins()).toBe(2);
+	});
+});

--- a/apps/server/src/userRoles.ts
+++ b/apps/server/src/userRoles.ts
@@ -1,0 +1,33 @@
+import { db, sqlite } from "./db";
+
+export type UserRole = "admin" | "user";
+
+/**
+ * Number of admins who can still sign in. Demoting or disabling the last one
+ * would lock everybody out of the admin surface, so every path that removes
+ * admin access checks this first.
+ */
+export function countActiveAdmins(): number {
+	const row = sqlite
+		.query(
+			"SELECT COUNT(*) AS count FROM user WHERE role = 'admin' AND isDisabled = 0",
+		)
+		.get() as { count: number };
+	return row.count;
+}
+
+/**
+ * Writes a user's role, revoking their API keys on demotion because keys
+ * authenticate as their owner and only admins may use them (`getSolarSession`).
+ *
+ * Callers own their own authorization and last-admin checks; this helper exists
+ * so the admin mutation and OIDC claim sync cannot drift apart.
+ */
+export async function applyUserRole(
+	userId: string,
+	role: UserRole,
+): Promise<void> {
+	sqlite.query("UPDATE user SET role = ? WHERE id = ?").run(role, userId);
+	if (role === "user")
+		await db.deleteFrom("apikey").where("referenceId", "=", userId).execute();
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,7 +20,7 @@
     "@tanstack/react-query": "^5.60.0",
     "@trpc/client": "^11.0.0",
     "@trpc/tanstack-react-query": "^11.0.0",
-    "better-auth": "^1.6.23",
+    "better-auth": "1.7.2",
     "bun-plugin-tailwind": "^0.1.2",
     "lucide-react": "^1.25.0",
     "react": "^19.0.0",

--- a/apps/web/src/AuthForm.test.tsx
+++ b/apps/web/src/AuthForm.test.tsx
@@ -13,28 +13,59 @@ const signInEmail = mock(
 	}): Promise<AuthResult> => ({ error: null }),
 );
 const signInSocial = mock(
-	async (_options: { provider: string }): Promise<AuthResult> => ({
+	async (_options: {
+		provider: string;
+		errorCallbackURL?: string;
+	}): Promise<AuthResult> => ({
 		error: null,
 	}),
 );
+const signInSocialOidc = mock(
+	async (_options: {
+		provider: string;
+		callbackURL?: string;
+		errorCallbackURL?: string;
+	}): Promise<AuthResult> => ({ error: null }),
+);
 
+// Google and OIDC now share signIn.social; route by provider so each
+// assertion can see only its own call.
 mock.module("./auth", () => ({
-	signIn: { email: signInEmail, social: signInSocial },
+	signIn: {
+		email: signInEmail,
+		social: (options: { provider: string }) =>
+			options.provider === "oidc"
+				? signInSocialOidc(options as never)
+				: signInSocial(options as never),
+	},
 }));
 mock.module("./ThemeToggle", () => ({ ThemeToggle: () => null }));
 
 let googleEnabled = true;
+let oidcProvider: { displayName: string } | null = { displayName: "Keycloak" };
 mock.module("./authProviders", () => ({
 	useGoogleAuthEnabled: () => googleEnabled,
+	useOidcProvider: () => oidcProvider,
 	useAirgapMode: () => false,
 }));
 
-const { AuthForm } = await import("./AuthForm");
+const { AuthForm, describeAuthError } = await import("./AuthForm");
+
+// Happy DOM starts at about:blank, where a relative replaceState cannot
+// resolve, so point the environment at a real origin first.
+function setSearch(search: string) {
+	(
+		window as unknown as { happyDOM?: { setURL?: (url: string) => void } }
+	).happyDOM?.setURL?.(`http://localhost/${search}`);
+}
 
 beforeEach(() => {
 	signInEmail.mockClear();
 	signInSocial.mockClear();
+	signInSocialOidc.mockClear();
 	googleEnabled = true;
+	oidcProvider = { displayName: "Keycloak" };
+	setSearch("");
 });
 
 describe("AuthForm", () => {
@@ -71,7 +102,10 @@ describe("AuthForm", () => {
 			screen.getByRole("button", { name: "Continue with Google" }),
 		);
 
-		expect(signInSocial).toHaveBeenCalledWith({ provider: "google" });
+		expect(signInSocial).toHaveBeenCalledWith({
+			provider: "google",
+			errorCallbackURL: "/",
+		});
 	});
 
 	test("hides the Google button when Google is not configured", () => {
@@ -81,5 +115,79 @@ describe("AuthForm", () => {
 		expect(
 			screen.queryByRole("button", { name: "Continue with Google" }),
 		).not.toBeInTheDocument();
+	});
+
+	test("starts OIDC sign-in with the configured provider name", async () => {
+		const user = userEvent.setup();
+		render(<AuthForm />);
+
+		await user.click(
+			screen.getByRole("button", { name: "Continue with Keycloak" }),
+		);
+
+		expect(signInSocialOidc).toHaveBeenCalledWith({
+			provider: "oidc",
+			callbackURL: "/",
+			errorCallbackURL: "/",
+		});
+	});
+
+	test("hides the OIDC button when no provider is configured", () => {
+		oidcProvider = null;
+		render(<AuthForm />);
+
+		expect(
+			screen.queryByRole("button", { name: /^Continue with/ }),
+		).toHaveTextContent("Continue with Google");
+	});
+
+	test("shows a readable reason when a provider redirects back an error", () => {
+		setSearch("?error=signup_disabled");
+		render(<AuthForm />);
+
+		expect(
+			screen.getByText(
+				"No Solar account exists for this email. Ask an admin to create one.",
+			),
+		).toBeInTheDocument();
+	});
+
+	test("clears the error from the address bar", () => {
+		setSearch("?error=signup_disabled&keep=1");
+		render(<AuthForm />);
+
+		expect(window.location.search).toBe("?keep=1");
+	});
+});
+
+describe("describeAuthError", () => {
+	test("prefers a known code over the raw description", () => {
+		expect(describeAuthError("access_denied", "whatever")).toBe(
+			"Sign-in was cancelled.",
+		);
+	});
+
+	test("prefers Solar's own copy for codes it raises itself", () => {
+		expect(
+			describeAuthError("ACCOUNT_DISABLED", "This account is disabled"),
+		).toBe("This account is disabled.");
+	});
+
+	test("falls back to the provider's description for unmapped codes", () => {
+		expect(describeAuthError("weird_code", "Something the IdP said")).toBe(
+			"Something the IdP said",
+		);
+	});
+
+	test("unpacks a hook message carried in the code", () => {
+		expect(describeAuthError("Email_domain_is_not_allowed")).toBe(
+			"Email domain is not allowed",
+		);
+	});
+
+	test("falls back to naming the unknown code", () => {
+		expect(describeAuthError("some_future_code")).toBe(
+			"Sign-in failed (some future code)",
+		);
 	});
 });

--- a/apps/web/src/AuthForm.tsx
+++ b/apps/web/src/AuthForm.tsx
@@ -1,20 +1,102 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { signIn } from "./auth";
-import { useGoogleAuthEnabled } from "./authProviders";
+import { useGoogleAuthEnabled, useOidcProvider } from "./authProviders";
 import { ThemeToggle } from "./ThemeToggle";
 
-/** Minimal email/password login. */
+const RETRY = "Sign-in expired. Please try again.";
+
+const AUTH_ERROR_MESSAGES: Record<string, string> = {
+	signup_disabled:
+		"No Solar account exists for this email. Ask an admin to create one.",
+	account_not_linked:
+		"This email is already registered with a different sign-in method.",
+	account_already_linked_to_different_user:
+		"That identity is already linked to another Solar account.",
+	unable_to_link_account: "Could not link this identity to a Solar account.",
+	unable_to_create_user: "Could not create an account for this sign-in.",
+	email_not_found: "The identity provider did not return an email address.",
+	email_not_verified:
+		"The identity provider has not verified this email address.",
+	email_does_not_match: "That identity uses a different email address.",
+	unable_to_get_user_info:
+		"Could not read your profile from the identity provider.",
+	issuer_mismatch:
+		"The identity provider's issuer does not match its configuration.",
+	EMAIL_DOMAIN_NOT_ALLOWED:
+		"That email domain is not allowed to sign in to this deployment.",
+	ACCOUNT_DISABLED: "This account is disabled.",
+	access_denied: "Sign-in was cancelled.",
+	state_mismatch: RETRY,
+	state_not_found: RETRY,
+	state_security_mismatch: RETRY,
+	nonce_binding_missing: RETRY,
+	invalid_code: RETRY,
+	no_code: RETRY,
+};
+
+/**
+ * Turns a redirected OAuth failure into something a person can act on.
+ *
+ * Better Auth sends its own lowercase codes; errors thrown by Solar's database
+ * hooks arrive as their message with spaces replaced by underscores, and codes
+ * we raise ourselves carry a readable description.
+ */
+export function describeAuthError(
+	code: string,
+	description?: string | null,
+): string {
+	const known = AUTH_ERROR_MESSAGES[code];
+	if (known) return known;
+	if (description) return description;
+	const spaced = code.replace(/_/g, " ");
+	return /^[a-z]/.test(spaced) ? `Sign-in failed (${spaced})` : spaced;
+}
+
+/** Minimal email/password login, plus any configured identity providers. */
 export function AuthForm() {
 	const [email, setEmail] = useState("");
 	const [password, setPassword] = useState("");
 	const [error, setError] = useState<string | null>(null);
 	const [busy, setBusy] = useState(false);
 	const googleEnabled = useGoogleAuthEnabled();
+	const oidcProvider = useOidcProvider();
+
+	// A failed provider sign-in redirects back here with the reason in the
+	// query string, since the redirect means signIn() never returns an error.
+	useEffect(() => {
+		const params = new URLSearchParams(window.location.search);
+		const code = params.get("error");
+		if (!code) return;
+		setError(describeAuthError(code, params.get("error_description")));
+		params.delete("error");
+		params.delete("error_description");
+		const query = params.toString();
+		window.history.replaceState(
+			null,
+			"",
+			`${window.location.pathname}${query ? `?${query}` : ""}${window.location.hash}`,
+		);
+	}, []);
 
 	async function signInWithGoogle() {
 		setBusy(true);
 		setError(null);
-		const res = await signIn.social({ provider: "google" });
+		const res = await signIn.social({
+			provider: "google",
+			errorCallbackURL: "/",
+		});
+		setBusy(false);
+		if (res.error) setError(res.error.message ?? "Authentication failed");
+	}
+
+	async function signInWithOidc() {
+		setBusy(true);
+		setError(null);
+		const res = await signIn.social({
+			provider: "oidc",
+			callbackURL: "/",
+			errorCallbackURL: "/",
+		});
 		setBusy(false);
 		if (res.error) setError(res.error.message ?? "Authentication failed");
 	}
@@ -69,21 +151,36 @@ export function AuthForm() {
 							Sign in
 						</button>
 					</form>
-					{googleEnabled && (
-						<>
+					{(googleEnabled || oidcProvider) && (
+						<div className="grid gap-3">
 							<div className="divider my-0">or</div>
-							<button
-								className="btn w-full"
-								type="button"
-								onClick={signInWithGoogle}
-								disabled={busy}
-							>
-								{busy && (
-									<span className="loading loading-spinner loading-sm" />
-								)}
-								Continue with Google
-							</button>
-						</>
+							{googleEnabled && (
+								<button
+									className="btn w-full"
+									type="button"
+									onClick={signInWithGoogle}
+									disabled={busy}
+								>
+									{busy && (
+										<span className="loading loading-spinner loading-sm" />
+									)}
+									Continue with Google
+								</button>
+							)}
+							{oidcProvider && (
+								<button
+									className="btn w-full"
+									type="button"
+									onClick={signInWithOidc}
+									disabled={busy}
+								>
+									{busy && (
+										<span className="loading loading-spinner loading-sm" />
+									)}
+									Continue with {oidcProvider.displayName}
+								</button>
+							)}
+						</div>
 					)}
 					{error && <p className="text-error">{error}</p>}
 				</div>

--- a/apps/web/src/AuthForm.tsx
+++ b/apps/web/src/AuthForm.tsx
@@ -89,6 +89,7 @@ export function AuthForm() {
 		if (res.error) setError(res.error.message ?? "Authentication failed");
 	}
 
+	/** Starts OIDC sign-in and returns both success and failure to this page. */
 	async function signInWithOidc() {
 		setBusy(true);
 		setError(null);

--- a/apps/web/src/auth.ts
+++ b/apps/web/src/auth.ts
@@ -1,5 +1,10 @@
 import { createAuthClient } from "better-auth/react";
 
-/** Better Auth browser client. Same-origin; talks to /api/auth/*. */
+/**
+ * Better Auth browser client. Same-origin; talks to /api/auth/*.
+ *
+ * Generic OAuth providers go through `signIn.social` like the built-in ones,
+ * so no client plugin is needed for OIDC.
+ */
 export const authClient = createAuthClient();
 export const { useSession, signIn, signUp, signOut } = authClient;

--- a/apps/web/src/authProviders.ts
+++ b/apps/web/src/authProviders.ts
@@ -8,6 +8,16 @@ export function useGoogleAuthEnabled(): boolean {
 	return data?.google ?? false;
 }
 
+/**
+ * The configured OpenID Connect provider, or null when none is set up or the
+ * query has not loaded. Only the button label crosses the wire.
+ */
+export function useOidcProvider(): { displayName: string } | null {
+	const trpc = useTRPC();
+	const { data } = useQuery(trpc.authProviders.queryOptions());
+	return data?.oidc ?? null;
+}
+
 /** Whether Airgap Mode is enabled on the server. False until loaded. */
 export function useAirgapMode(): boolean {
 	const trpc = useTRPC();

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
       "name": "@solar/server",
       "version": "0.0.0",
       "dependencies": {
-        "@better-auth/api-key": "^1.6.23",
+        "@better-auth/api-key": "1.7.2",
         "@earendil-works/pi-agent-core": "0.80.10",
         "@earendil-works/pi-ai": "0.80.10",
         "@earendil-works/pi-coding-agent": "0.84.2",
@@ -32,7 +32,7 @@
         "@solar/web": "workspace:*",
         "@struktoai/mirage-node": "^0.0.3",
         "@trpc/server": "^11.0.0",
-        "better-auth": "^1.6.23",
+        "better-auth": "1.7.2",
         "bun-plugin-tailwind": "^0.1.2",
         "hono": "^4.6.0",
         "kysely": "^0.27.4",
@@ -64,7 +64,7 @@
         "@tanstack/react-query": "^5.60.0",
         "@trpc/client": "^11.0.0",
         "@trpc/tanstack-react-query": "^11.0.0",
-        "better-auth": "^1.6.23",
+        "better-auth": "1.7.2",
         "bun-plugin-tailwind": "^0.1.2",
         "lucide-react": "^1.25.0",
         "react": "^19.0.0",
@@ -351,21 +351,21 @@
 
     "@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
 
-    "@better-auth/api-key": ["@better-auth/api-key@1.6.23", "", { "dependencies": { "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/core": "^1.6.23", "@better-auth/utils": "0.4.2", "better-auth": "^1.6.23", "better-call": "1.3.7" } }, "sha512-HQMTv1GkY5FzE8BlUXdNhuKPBPUvusBYlAtIQElQjfsmGiPiBie7BdzuhcbXhAqJerunU299yvEge2WlZusp+Q=="],
+    "@better-auth/api-key": ["@better-auth/api-key@1.7.2", "", { "dependencies": { "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/core": "^1.7.2", "@better-auth/utils": "0.4.2", "better-auth": "^1.7.2", "better-call": "1.4.0" } }, "sha512-jih45wZaQ83lVYdChSnasxb8iax8p7AYetZ/XiImA9Yuag+cqmLBsaLPNvds5aZV18hLpmvzVkuzf7H/k1X88g=="],
 
-    "@better-auth/core": ["@better-auth/core@1.6.23", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.39.0", "@standard-schema/spec": "^1.1.0", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/utils": "0.4.2", "@better-fetch/fetch": "1.3.1", "@cloudflare/workers-types": ">=4", "@opentelemetry/api": "^1.9.0", "better-call": "1.3.7", "jose": "^6.1.0", "kysely": "^0.28.5 || ^0.29.0", "nanostores": "^1.0.1" }, "optionalPeers": ["@cloudflare/workers-types", "@opentelemetry/api"] }, "sha512-beEhOs0uVeOxYOZKUfIEBd/nQV2Bd4/6wyLxZ0OFkn6CMTK2Vi+hXuZLnyPBeB6RdHpebEoJWiHqwHxBIxgPDQ=="],
+    "@better-auth/core": ["@better-auth/core@1.7.2", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.41.1", "@standard-schema/spec": "^1.1.0", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/utils": "0.4.2", "@better-fetch/fetch": "1.3.1", "@cloudflare/workers-types": ">=4", "@opentelemetry/api": "^1.9.0", "better-call": "1.4.0", "jose": "^6.1.0", "kysely": "^0.28.5 || ^0.29.0", "nanostores": "^1.0.1" }, "optionalPeers": ["@cloudflare/workers-types", "@opentelemetry/api"] }, "sha512-j0nM4ygsWbF/fcYRoKtDn8gn8uLXkmC+075HqSqsJEAV828cJR9bvYBCUQ1zmxNyRBk6Iz/qXsA0Zm2oksiOTg=="],
 
-    "@better-auth/drizzle-adapter": ["@better-auth/drizzle-adapter@1.6.23", "", { "peerDependencies": { "@better-auth/core": "^1.6.23", "@better-auth/utils": "0.4.2", "drizzle-orm": "^0.45.2" }, "optionalPeers": ["drizzle-orm"] }, "sha512-2+/PTVfIP9E7iz6af8TB3lhnowHUj9ljC66kECmHaFEdUqPgzHoWux9epotKwO7XDg2ui4ttWQ8CMeNFLvQeKQ=="],
+    "@better-auth/drizzle-adapter": ["@better-auth/drizzle-adapter@1.7.2", "", { "peerDependencies": { "@better-auth/core": "^1.7.2", "@better-auth/utils": "0.4.2", "drizzle-orm": "^0.45.2 || >=1.0.0-rc.1 <2.0.0" }, "optionalPeers": ["drizzle-orm"] }, "sha512-A5wE10PIv3aS5LGePecEHntQylKy6OOF17B4dqlE0DwJeqU/IOBSd7/LZhMop9cNJ3WFjKMpazVSf91yYM/NFg=="],
 
-    "@better-auth/kysely-adapter": ["@better-auth/kysely-adapter@1.6.23", "", { "peerDependencies": { "@better-auth/core": "^1.6.23", "@better-auth/utils": "0.4.2", "kysely": "^0.28.17 || ^0.29.0" }, "optionalPeers": ["kysely"] }, "sha512-zbNJsMbG09exfkGyvFqBLLqWoMPAUWjxCuUnEK5AsjbYoZeIjj/QGZgdf4CapVWryKxjA9Q6Jlr6fbiPpC3VAg=="],
+    "@better-auth/kysely-adapter": ["@better-auth/kysely-adapter@1.7.2", "", { "peerDependencies": { "@better-auth/core": "^1.7.2", "@better-auth/utils": "0.4.2", "kysely": "^0.28.17 || ^0.29.0" }, "optionalPeers": ["kysely"] }, "sha512-LYdSRLOvZiF+6S0UThu+wE/Qxsq9P2jQs7ZKkY6BIBJqUjYyxVDmi8HFcantBvWWW1/BeQCSsD7YVDG4gICMIQ=="],
 
-    "@better-auth/memory-adapter": ["@better-auth/memory-adapter@1.6.23", "", { "peerDependencies": { "@better-auth/core": "^1.6.23", "@better-auth/utils": "0.4.2" } }, "sha512-krIiR0pIVkaKlAzm690n5bcMW4NGbqeMg0HQSD9fz/KcQF/eWLqcq9gG/BhHTj2i/y96qH+W5JWPmaSOS5iTgQ=="],
+    "@better-auth/memory-adapter": ["@better-auth/memory-adapter@1.7.2", "", { "peerDependencies": { "@better-auth/core": "^1.7.2", "@better-auth/utils": "0.4.2" } }, "sha512-0q1SXMzm5esH9L0xVuM6IxCk59E4G+3HySX4My9gvEwqtmUobykn+iuc/si3Y4xwUO7JODqQ5o+/pPcLDDMIrA=="],
 
-    "@better-auth/mongo-adapter": ["@better-auth/mongo-adapter@1.6.23", "", { "peerDependencies": { "@better-auth/core": "^1.6.23", "@better-auth/utils": "0.4.2", "mongodb": "^6.0.0 || ^7.0.0" }, "optionalPeers": ["mongodb"] }, "sha512-7+QdevitGlKBbP6JbiSk5SBnzPsKV/mDrQBGBn8hwByQLeJwqpqbuBPw7ZI8vzUlFfAAnyFiqwP3Eb8mxnp7pA=="],
+    "@better-auth/mongo-adapter": ["@better-auth/mongo-adapter@1.7.2", "", { "peerDependencies": { "@better-auth/core": "^1.7.2", "@better-auth/utils": "0.4.2", "mongodb": "^6.0.0 || ^7.0.0" }, "optionalPeers": ["mongodb"] }, "sha512-4879SmUWHUs0OYlvHoCFbycZ7i1bqytkcgAUdt9RLQMvZ5H3LRMTgax2YVlGZEXgwNjY/X7xAoXOecWLhlQWeA=="],
 
-    "@better-auth/prisma-adapter": ["@better-auth/prisma-adapter@1.6.23", "", { "peerDependencies": { "@better-auth/core": "^1.6.23", "@better-auth/utils": "0.4.2", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["@prisma/client", "prisma"] }, "sha512-2qSdzidq4tkb1eS5TTqb4Nzg0mdZWm3Qky9SYeXeb8PpVQbC2sxqJhEM5mK7y12uU6I8hc64wO9f7AFVNL+6UQ=="],
+    "@better-auth/prisma-adapter": ["@better-auth/prisma-adapter@1.7.2", "", { "peerDependencies": { "@better-auth/core": "^1.7.2", "@better-auth/utils": "0.4.2", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["@prisma/client", "prisma"] }, "sha512-mXTr/83WrNWLrvzIjtgDgdu9iXhOcSG1+qBQOAKlbGSFiOB+z4IMRneQ2wmMOiB8mKY9qGkClVUjKRFXqtHnFQ=="],
 
-    "@better-auth/telemetry": ["@better-auth/telemetry@1.6.23", "", { "peerDependencies": { "@better-auth/core": "^1.6.23", "@better-auth/utils": "0.4.2", "@better-fetch/fetch": "1.3.1" } }, "sha512-/R2Kb+z2BpDOOWwVHqOk+c0VNpuwfCv4Hp5Yr9003WIZPax/zyNraGLB9CFE8qF2gZW8Dsz419k4I8CPrGzpDA=="],
+    "@better-auth/telemetry": ["@better-auth/telemetry@1.7.2", "", { "peerDependencies": { "@better-auth/core": "^1.7.2", "@better-auth/utils": "0.4.2", "@better-fetch/fetch": "1.3.1" } }, "sha512-LcWu+O0zrxYDQj8E36vfkJwGPW4k9ZDA/rCo0zST6ihzL+juR7pBowoZIM9E6tK0Vit52mf6412bGT4XM4eTjQ=="],
 
     "@better-auth/utils": ["@better-auth/utils@0.4.2", "", { "dependencies": { "@noble/hashes": "^2.0.1" } }, "sha512-AUxrvu+HaaODsUyzDxFgwd/8RZ1yZaYo42LXKSrU2oGgR38pS1ij8nqQKNgtTWoYGpNevNXtCfgTy6loHveW9A=="],
 
@@ -915,9 +915,9 @@
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.43", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ=="],
 
-    "better-auth": ["better-auth@1.6.23", "", { "dependencies": { "@better-auth/core": "1.6.23", "@better-auth/drizzle-adapter": "1.6.23", "@better-auth/kysely-adapter": "1.6.23", "@better-auth/memory-adapter": "1.6.23", "@better-auth/mongo-adapter": "1.6.23", "@better-auth/prisma-adapter": "1.6.23", "@better-auth/telemetry": "1.6.23", "@better-auth/utils": "0.4.2", "@better-fetch/fetch": "1.3.1", "@noble/ciphers": "^2.1.1", "@noble/hashes": "^2.0.1", "better-call": "1.3.7", "defu": "^6.1.4", "jose": "^6.1.3", "kysely": "^0.28.17 || ^0.29.0", "nanostores": "^1.1.1", "zod": "^4.3.6" }, "peerDependencies": { "@lynx-js/react": "*", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "@sveltejs/kit": "^2.0.0", "@tanstack/react-start": "^1.0.0", "@tanstack/solid-start": "^1.0.0", "better-sqlite3": "^12.0.0", "drizzle-kit": ">=0.31.4", "drizzle-orm": "^0.45.2", "mongodb": "^6.0.0 || ^7.0.0", "mysql2": "^3.0.0", "next": "^14.0.0 || ^15.0.0 || ^16.0.0", "pg": "^8.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "solid-js": "^1.0.0", "svelte": "^4.0.0 || ^5.0.0", "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@lynx-js/react", "@prisma/client", "@sveltejs/kit", "@tanstack/react-start", "@tanstack/solid-start", "better-sqlite3", "drizzle-kit", "drizzle-orm", "mongodb", "mysql2", "next", "pg", "prisma", "react", "react-dom", "solid-js", "svelte", "vitest", "vue"] }, "sha512-4vOaRd9UiKGKm9R+ej0jjU1es3MiJIiNc9Qq3VCnYqOZ4/nb5272QqTxWYoDxyUXl5x6A2x2we5KZKQO9teTQQ=="],
+    "better-auth": ["better-auth@1.7.2", "", { "dependencies": { "@better-auth/core": "1.7.2", "@better-auth/drizzle-adapter": "1.7.2", "@better-auth/kysely-adapter": "1.7.2", "@better-auth/memory-adapter": "1.7.2", "@better-auth/mongo-adapter": "1.7.2", "@better-auth/prisma-adapter": "1.7.2", "@better-auth/telemetry": "1.7.2", "@better-auth/utils": "0.4.2", "@better-fetch/fetch": "1.3.1", "@noble/ciphers": "^2.2.0", "@noble/hashes": "^2.2.0", "better-call": "1.4.0", "defu": "^6.1.4", "jose": "^6.2.3", "kysely": "^0.28.17 || ^0.29.0", "nanostores": "^1.3.0", "zod": "^4.3.6" }, "peerDependencies": { "@lynx-js/react": "*", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "@sveltejs/kit": "^2.0.0", "@tanstack/react-start": "^1.0.0", "@tanstack/solid-start": "^1.0.0", "better-sqlite3": "^12.0.0", "drizzle-kit": ">=0.31.4 || >=1.0.0-beta.1", "drizzle-orm": "^0.45.2 || >=1.0.0-rc.1 <2.0.0", "mongodb": "^6.0.0 || ^7.0.0", "mysql2": "^3.0.0", "next": "^14.0.0 || ^15.0.0 || ^16.0.0", "pg": "^8.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "solid-js": "^1.0.0", "svelte": "^4.0.0 || ^5.0.0", "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@lynx-js/react", "@prisma/client", "@sveltejs/kit", "@tanstack/react-start", "@tanstack/solid-start", "better-sqlite3", "drizzle-kit", "drizzle-orm", "mongodb", "mysql2", "next", "pg", "prisma", "react", "react-dom", "solid-js", "svelte", "vitest", "vue"] }, "sha512-gKapKBEvYIGcMxi74RjQ7EbFLiqyQt58vdoJmL1qAlWSkY1Bc2Vqshl524/3u1NxauiOU03M/Ebh762Brmac9A=="],
 
-    "better-call": ["better-call@1.3.7", "", { "dependencies": { "@better-auth/utils": "^0.4.0", "@better-fetch/fetch": "^1.1.21", "rou3": "^0.7.12", "set-cookie-parser": "^3.0.1" }, "peerDependencies": { "zod": "^4.0.0" }, "optionalPeers": ["zod"] }, "sha512-Al51/hjp2SSp6CRTa3F2ptcx4yQVS1xWKoY6jcVXqNYOap6mHFP2jUBn5EwIL4iIed1/Sq4hlQ+Umm6EflZG+w=="],
+    "better-call": ["better-call@1.4.0", "", { "dependencies": { "@better-auth/utils": "^0.5.0", "@better-fetch/fetch": "^1.3.1", "rou3": "^0.9.1", "set-cookie-parser": "^3.1.2" }, "peerDependencies": { "zod": "^4.0.0" }, "optionalPeers": ["zod"] }, "sha512-bBKOT4vv1kZLDgxVePdilk/Jwkn+dtRRsmi3DzHcDP+WnswyVl6dR59l2HEeP/0cB+bDoopASAesWDPIdd/zZA=="],
 
     "better-sqlite3": ["better-sqlite3@12.11.1", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA=="],
 
@@ -1761,7 +1761,7 @@
 
     "rollup": ["rollup@4.62.2", "", { "dependencies": { "@types/estree": "1.0.9" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.62.2", "@rollup/rollup-android-arm64": "4.62.2", "@rollup/rollup-darwin-arm64": "4.62.2", "@rollup/rollup-darwin-x64": "4.62.2", "@rollup/rollup-freebsd-arm64": "4.62.2", "@rollup/rollup-freebsd-x64": "4.62.2", "@rollup/rollup-linux-arm-gnueabihf": "4.62.2", "@rollup/rollup-linux-arm-musleabihf": "4.62.2", "@rollup/rollup-linux-arm64-gnu": "4.62.2", "@rollup/rollup-linux-arm64-musl": "4.62.2", "@rollup/rollup-linux-loong64-gnu": "4.62.2", "@rollup/rollup-linux-loong64-musl": "4.62.2", "@rollup/rollup-linux-ppc64-gnu": "4.62.2", "@rollup/rollup-linux-ppc64-musl": "4.62.2", "@rollup/rollup-linux-riscv64-gnu": "4.62.2", "@rollup/rollup-linux-riscv64-musl": "4.62.2", "@rollup/rollup-linux-s390x-gnu": "4.62.2", "@rollup/rollup-linux-x64-gnu": "4.62.2", "@rollup/rollup-linux-x64-musl": "4.62.2", "@rollup/rollup-openbsd-x64": "4.62.2", "@rollup/rollup-openharmony-arm64": "4.62.2", "@rollup/rollup-win32-arm64-msvc": "4.62.2", "@rollup/rollup-win32-ia32-msvc": "4.62.2", "@rollup/rollup-win32-x64-gnu": "4.62.2", "@rollup/rollup-win32-x64-msvc": "4.62.2", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA=="],
 
-    "rou3": ["rou3@0.7.12", "", {}, "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg=="],
+    "rou3": ["rou3@0.9.2", "", {}, "sha512-3SOzvaAg8rkHrXtRjpCvCvbyO5to9oOO27Z/XqHEYXfMRVSw/qMIVdmaOk9W2lcRLtR6dlqTjo9hDeJk70QBYQ=="],
 
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
@@ -2102,6 +2102,8 @@
     "babel-plugin-polyfill-corejs2/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "better-auth/kysely": ["kysely@0.29.4", "", {}, "sha512-y5mVgQNkMbs1eK9Xyc0pmNdabN2wHhRYY/5r4W5HrUT1rYCEPeVNSj1RUJeSDKT3U0p+mXCvLgkrFuIafYI6BA=="],
+
+    "better-call/@better-auth/utils": ["@better-auth/utils@0.5.0", "", { "dependencies": { "@noble/hashes": "^2.0.1" } }, "sha512-BL8W4EfIZFwlu0r54m3v1ztjDhu6dDe/amLTm0xybmbZaNgYUqhD3SjpAsnq0q8YD6/ki4iwIgxJNLP/N3TxiA=="],
 
     "bl/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 


### PR DESCRIPTION
Adds optional sign-in through a single self-hosted OpenID Connect provider, alongside the existing Google OAuth and email/password paths, and pins `better-auth` / `@better-auth/api-key` to 1.7.2.

Nothing changes for existing deployments: OIDC stays off until `OIDC_ISSUER`, `OIDC_CLIENT_ID`, and `OIDC_CLIENT_SECRET` are all set, and a partial set logs a warning rather than half-enabling the flow.

## What this adds

- **OIDC sign-in** (`apps/server/src/oidc.ts`) — endpoints discovered from `${OIDC_ISSUER}/.well-known/openid-configuration`, PKCE on every sign-in, and ID token signature + nonce verification when the discovery document advertises a JWKS endpoint.
- **Transport hardening** — issuer and discovered userinfo endpoint must be HTTPS; cleartext HTTP is accepted only for `localhost`, `127.0.0.1`, and `[::1]`.
- **Sign-in button** — the web sign-in page shows "Continue with `OIDC_DISPLAY_NAME`" (default `SSO`) only when the provider is configured.
- **Optional group→admin mapping** — set both `OIDC_ADMIN_CLAIM` and `OIDC_ADMIN_VALUE` and the admin role is re-derived on every OIDC sign-in, so removing someone from the group at the IdP demotes them (and revokes their API keys) on next sign-in. Solar refuses to demote the last remaining admin. Left unset, roles stay manually managed in Settings.
- **Account linking** — an IdP identity links to an existing account only on an exact email match; differing addresses are never linked, matching the Google behaviour.
- **Signup control** — first sign-in provisions the account (still subject to `AUTH_ALLOWED_DOMAINS`); `OIDC_DISABLE_SIGNUP=1` requires an admin to create the user first.
- **Airgap** — OIDC stays enabled under `SOLAR_AIRGAP_MODE` on the grounds that a self-hosted IdP is the operator's own service, not a third-party call. Google OAuth remains disabled there.
- **Fail-loud callback check** — role sync hangs off Better Auth's OAuth callback route, so startup asserts that route is still registered rather than silently freezing every admin role if a future release renames it.

## New environment variables

All optional; see `.env.example` and the README's "OIDC / SSO" section for per-provider issuer and group-claim values (Authentik, Keycloak, Zitadel, Authelia).

| Variable | Purpose |
| --- | --- |
| `BETTER_AUTH_URL` | Public base URL; every OAuth redirect URI derives from it |
| `OIDC_ISSUER` / `OIDC_CLIENT_ID` / `OIDC_CLIENT_SECRET` | All three enable the provider |
| `OIDC_DISPLAY_NAME` / `OIDC_SCOPES` / `OIDC_DISABLE_SIGNUP` | Button label, requested scopes, whether first sign-in may provision |
| `OIDC_ADMIN_CLAIM` / `OIDC_ADMIN_VALUE` | Optional group claim and value granting admin |

Redirect URI to register at the provider: `${BETTER_AUTH_URL}/api/auth/callback/oidc`

## Dependency change

`better-auth` and `@better-auth/api-key` move from `^1.6.23` to a pinned `1.7.2` (the generic OIDC provider support this builds on). Pinned rather than caret-ranged so an auth-critical dependency does not float.

## Testing

Run against the merge head (`6a3eced`):

- `bun run test` — 164 server pass / 0 fail, 63 web pass / 0 fail
- `bun run typecheck` — clean

New unit tests cover OIDC discovery and claim extraction (`oidc.test.ts`), issuer URL validation (`oidcUrl.ts`), account issuer resolution, the auth-table migration, config parsing, role mapping (`userRoles.test.ts`), and the sign-in form.

Not covered here: an end-to-end run against a live IdP. Manual verification against a real provider before merge would be worthwhile.

## Commits

- `cacb93e` feat(auth): add OIDC sign-in and upgrade better-auth to 1.7
- `5a5e415` fix(auth): harden OIDC sign-in and migration
- `b6dd15f` fix(auth): fail closed on missing OIDC issuer
- `d48a573` fix(auth): reject invalid OIDC issuer suffixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdjznCm2a7PFHaKxrYdVFf
