### PR TITLE
fix(mcp): list prompts and resources only when the server declares them

### DIFF
--- a/apps/server/src/chat/mcp.test.ts
+++ b/apps/server/src/chat/mcp.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, mock, test } from "bun:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+// mcp.ts imports the shared sqlite handle; none of these tests touch it.
+mock.module("../db", () => ({ db: {} }));
+const { discoverMcpServer, toolsForServer } = await import("./mcp");
+
+async function connectTo(server: McpServer): Promise<Client> {
+	const [clientTransport, serverTransport] =
+		InMemoryTransport.createLinkedPair();
+	await server.connect(serverTransport);
+	const client = new Client({ name: "test", version: "0.0.0" });
+	await client.connect(clientTransport);
+	return client;
+}
+
+const echo = async () => ({ content: [{ type: "text" as const, text: "ok" }] });
+
+describe("discoverMcpServer", () => {
+	test("asks only for what the server declares, so a tools-only server is not dropped", async () => {
+		// A server with tools but no prompts capability answers prompts/list with
+		// JSON-RPC -32601 (Method not found). Listing unconditionally turned that
+		// into a thrown error and the whole server was skipped.
+		const server = new McpServer({ name: "tools-only", version: "1.0.0" });
+		server.registerTool(
+			"search",
+			{ description: "Search", inputSchema: { query: z.string() } },
+			echo,
+		);
+		const found = await discoverMcpServer(await connectTo(server));
+		expect(found.tools.map((tool) => tool.name)).toEqual(["search"]);
+		expect(found.prompts).toEqual([]);
+		expect(found.resources).toEqual([]);
+		expect(found.capabilities).toEqual({ prompts: false, resources: false });
+	});
+
+	test("still lists prompts and resources when the server declares them", async () => {
+		const server = new McpServer({ name: "full", version: "1.0.0" });
+		server.registerTool("t", { description: "t" }, echo);
+		server.registerPrompt("p", { description: "p" }, () => ({
+			messages: [{ role: "user", content: { type: "text", text: "hi" } }],
+		}));
+		server.registerResource(
+			"r",
+			"res://r",
+			{ description: "r", mimeType: "text/plain" },
+			async () => ({ contents: [{ uri: "res://r", text: "x" }] }),
+		);
+		const found = await discoverMcpServer(await connectTo(server));
+		expect(found.tools.map((tool) => tool.name)).toEqual(["t"]);
+		expect(found.prompts.map((prompt) => prompt.name)).toEqual(["p"]);
+		expect(found.resources.map((resource) => resource.uri)).toEqual([
+			"res://r",
+		]);
+		expect(found.capabilities).toEqual({ prompts: true, resources: true });
+	});
+});
+
+describe("toolsForServer", () => {
+	const server = {
+		id: "abc-def",
+		name: "Web search",
+		url: "http://searxng-mcp:3000/mcp",
+		headers: "{}",
+	};
+	const search = {
+		name: "search",
+		description: "Search",
+		inputSchema: { type: "object" as const },
+	};
+
+	test("omits the prompt and resource helper tools a server cannot serve", () => {
+		const names = toolsForServer(server, {
+			tools: [search],
+			prompts: [],
+			resources: [],
+			capabilities: { prompts: false, resources: true },
+		}).map((resolved) => resolved.remoteName);
+		expect(names).toEqual(["search", "list_resources", "read_resource"]);
+	});
+
+	test("keeps every helper tool for a server that declares both", () => {
+		const names = toolsForServer(server, {
+			tools: [search],
+			prompts: [],
+			resources: [],
+			capabilities: { prompts: true, resources: true },
+		}).map((resolved) => resolved.remoteName);
+		expect(names).toEqual([
+			"search",
+			"list_prompts",
+			"get_prompt",
+			"list_resources",
+			"read_resource",
+		]);
+	});
+
+	test("namespaces remote tool names by server id", () => {
+		const [resolved] = toolsForServer(server, {
+			tools: [search],
+			prompts: [],
+			resources: [],
+			capabilities: { prompts: false, resources: false },
+		});
+		if (!resolved) throw new Error("expected one resolved tool");
+		expect(resolved.tool.name).toBe("mcp_abc_def_search");
+		expect(resolved.tool.description).toBe("[Web search] Search");
+	});
+});

--- a/apps/server/src/chat/mcp.test.ts
+++ b/apps/server/src/chat/mcp.test.ts
@@ -37,6 +37,30 @@ describe("discoverMcpServer", () => {
 		expect(found.capabilities).toEqual({ prompts: false, resources: false });
 	});
 
+	test("lists tools even when the server did not declare the tools capability", async () => {
+		// Proxies, gateways and older frameworks answer tools/list without
+		// advertising `tools`. Trusting the declaration there would drop every
+		// tool with no error. Only the optional prompts/resources calls are
+		// gated; tools/list is always asked, as it was before this change.
+		const stub = {
+			getServerCapabilities: () => ({}),
+			listTools: async () => ({
+				tools: [{ name: "search", inputSchema: { type: "object" } }],
+			}),
+			listPrompts: async () => {
+				throw new Error("prompts/list must not be called");
+			},
+			listResources: async () => {
+				throw new Error("resources/list must not be called");
+			},
+		} as unknown as Client;
+		const found = await discoverMcpServer(stub);
+		expect(found.tools.map((tool) => tool.name)).toEqual(["search"]);
+		expect(found.prompts).toEqual([]);
+		expect(found.resources).toEqual([]);
+		expect(found.capabilities).toEqual({ prompts: false, resources: false });
+	});
+
 	test("still lists prompts and resources when the server declares them", async () => {
 		const server = new McpServer({ name: "full", version: "1.0.0" });
 		server.registerTool("t", { description: "t" }, echo);

--- a/apps/server/src/chat/mcp.ts
+++ b/apps/server/src/chat/mcp.ts
@@ -1,5 +1,10 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type {
+	Prompt,
+	Resource,
+	Tool as McpTool,
+} from "@modelcontextprotocol/sdk/types.js";
 import { Type, type Tool } from "@earendil-works/pi-ai";
 import { db } from "../db";
 
@@ -55,6 +60,41 @@ async function withClient<T>(
 	}
 }
 
+export interface McpDiscovery {
+	tools: McpTool[];
+	prompts: Prompt[];
+	resources: Resource[];
+	/** Which optional list/get helpers the server can actually answer. */
+	capabilities: { prompts: boolean; resources: boolean };
+}
+
+/**
+ * Lists what a connected server offers, asking only for the capabilities it
+ * declared during initialize. A server without the `prompts` capability
+ * answers `prompts/list` with JSON-RPC -32601 (Method not found); listing
+ * everything unconditionally turned that into a thrown error, and a
+ * tools-only server (most search or fetch servers) was silently dropped.
+ */
+export async function discoverMcpServer(client: Client): Promise<McpDiscovery> {
+	const declared = client.getServerCapabilities() ?? {};
+	const [tools, prompts, resources] = await Promise.all([
+		declared.tools ? client.listTools() : Promise.resolve({ tools: [] }),
+		declared.prompts ? client.listPrompts() : Promise.resolve({ prompts: [] }),
+		declared.resources
+			? client.listResources()
+			: Promise.resolve({ resources: [] }),
+	]);
+	return {
+		tools: tools.tools,
+		prompts: prompts.prompts,
+		resources: resources.resources,
+		capabilities: {
+			prompts: Boolean(declared.prompts),
+			resources: Boolean(declared.resources),
+		},
+	};
+}
+
 export async function testMcpServer(
 	url: string,
 	headers: Record<string, string>,
@@ -67,19 +107,124 @@ export async function testMcpServer(
 	return withClient(
 		{ id: "test", name: "test", url, headers: JSON.stringify(headers) },
 		async (client) => {
-			const [tools, prompts, resources] = await Promise.all([
-				client.listTools(),
-				client.listPrompts(),
-				client.listResources(),
-			]);
+			const found = await discoverMcpServer(client);
 			return {
 				name: client.getServerVersion()?.name,
-				tools: tools.tools.length,
-				prompts: prompts.prompts.length,
-				resources: resources.resources.length,
+				tools: found.tools.length,
+				prompts: found.prompts.length,
+				resources: found.resources.length,
 			};
 		},
 	);
+}
+
+/**
+ * The model-facing tools for one server: each remote tool, plus the prompt
+ * and resource helpers - only for the capabilities the server declared, so
+ * the model is never offered a helper that can only fail.
+ */
+export function toolsForServer(
+	server: ServerRow,
+	discovered: McpDiscovery,
+): ResolvedTool[] {
+	const result: ResolvedTool[] = [];
+	for (const remote of discovered.tools) {
+		result.push({
+			tool: {
+				name: toolName(server.id, remote.name),
+				description: `[${server.name}] ${remote.description ?? remote.name}`,
+				parameters: Type.Unsafe(remote.inputSchema),
+			},
+			serverName: server.name,
+			remoteName: remote.name,
+			execute: async (args) =>
+				withClient(server, async (client) => {
+					const response = await client.callTool({
+						name: remote.name,
+						arguments: args,
+					});
+					return {
+						content: asText(response),
+						isError: "isError" in response && Boolean(response.isError),
+					};
+				}),
+		});
+	}
+	if (discovered.capabilities.prompts) {
+		result.push({
+			tool: {
+				name: toolName(server.id, "list_prompts"),
+				description: `[${server.name}] List available MCP prompts`,
+				parameters: Type.Object({}),
+			},
+			serverName: server.name,
+			remoteName: "list_prompts",
+			execute: async () => ({
+				content: asText(
+					await withClient(server, (client) => client.listPrompts()),
+				),
+				isError: false,
+			}),
+		});
+		result.push({
+			tool: {
+				name: toolName(server.id, "get_prompt"),
+				description: `[${server.name}] Get an MCP prompt by name`,
+				parameters: Type.Object({
+					name: Type.String(),
+					arguments: Type.Optional(Type.Record(Type.String(), Type.String())),
+				}),
+			},
+			serverName: server.name,
+			remoteName: "get_prompt",
+			execute: async (args) => ({
+				content: asText(
+					await withClient(server, (client) =>
+						client.getPrompt({
+							name: String(args.name),
+							arguments: args.arguments as Record<string, string> | undefined,
+						}),
+					),
+				),
+				isError: false,
+			}),
+		});
+	}
+	if (discovered.capabilities.resources) {
+		result.push({
+			tool: {
+				name: toolName(server.id, "list_resources"),
+				description: `[${server.name}] List available MCP resources`,
+				parameters: Type.Object({}),
+			},
+			serverName: server.name,
+			remoteName: "list_resources",
+			execute: async () => ({
+				content: asText(
+					await withClient(server, (client) => client.listResources()),
+				),
+				isError: false,
+			}),
+		});
+		result.push({
+			tool: {
+				name: toolName(server.id, "read_resource"),
+				description: `[${server.name}] Read an MCP resource by URI`,
+				parameters: Type.Object({ uri: Type.String() }),
+			},
+			serverName: server.name,
+			remoteName: "read_resource",
+			execute: async (args) => ({
+				content: asText(
+					await withClient(server, (client) =>
+						client.readResource({ uri: String(args.uri) }),
+					),
+				),
+				isError: false,
+			}),
+		});
+	}
+	return result;
 }
 
 /**
@@ -152,105 +297,8 @@ export async function resolveMcpTools(
 	const result: ResolvedTool[] = [];
 	for (const server of active) {
 		try {
-			const discovered = await withClient(server, async (client) =>
-				Promise.all([
-					client.listTools(),
-					client.listPrompts(),
-					client.listResources(),
-				]),
-			);
-			for (const remote of discovered[0].tools) {
-				result.push({
-					tool: {
-						name: toolName(server.id, remote.name),
-						description: `[${server.name}] ${remote.description ?? remote.name}`,
-						parameters: Type.Unsafe(remote.inputSchema),
-					},
-					serverName: server.name,
-					remoteName: remote.name,
-					execute: async (args) =>
-						withClient(server, async (client) => {
-							const response = await client.callTool({
-								name: remote.name,
-								arguments: args,
-							});
-							return {
-								content: asText(response),
-								isError: "isError" in response && Boolean(response.isError),
-							};
-						}),
-				});
-			}
-			result.push({
-				tool: {
-					name: toolName(server.id, "list_prompts"),
-					description: `[${server.name}] List available MCP prompts`,
-					parameters: Type.Object({}),
-				},
-				serverName: server.name,
-				remoteName: "list_prompts",
-				execute: async () => ({
-					content: asText(
-						await withClient(server, (client) => client.listPrompts()),
-					),
-					isError: false,
-				}),
-			});
-			result.push({
-				tool: {
-					name: toolName(server.id, "get_prompt"),
-					description: `[${server.name}] Get an MCP prompt by name`,
-					parameters: Type.Object({
-						name: Type.String(),
-						arguments: Type.Optional(Type.Record(Type.String(), Type.String())),
-					}),
-				},
-				serverName: server.name,
-				remoteName: "get_prompt",
-				execute: async (args) => ({
-					content: asText(
-						await withClient(server, (client) =>
-							client.getPrompt({
-								name: String(args.name),
-								arguments: args.arguments as Record<string, string> | undefined,
-							}),
-						),
-					),
-					isError: false,
-				}),
-			});
-			result.push({
-				tool: {
-					name: toolName(server.id, "list_resources"),
-					description: `[${server.name}] List available MCP resources`,
-					parameters: Type.Object({}),
-				},
-				serverName: server.name,
-				remoteName: "list_resources",
-				execute: async () => ({
-					content: asText(
-						await withClient(server, (client) => client.listResources()),
-					),
-					isError: false,
-				}),
-			});
-			result.push({
-				tool: {
-					name: toolName(server.id, "read_resource"),
-					description: `[${server.name}] Read an MCP resource by URI`,
-					parameters: Type.Object({ uri: Type.String() }),
-				},
-				serverName: server.name,
-				remoteName: "read_resource",
-				execute: async (args) => ({
-					content: asText(
-						await withClient(server, (client) =>
-							client.readResource({ uri: String(args.uri) }),
-						),
-					),
-					isError: false,
-				}),
-			});
+			const discovered = await withClient(server, discoverMcpServer);
+			result.push(...toolsForServer(server, discovered));
 		} catch {
 			// An unavailable server must not prevent unrelated servers or chat from working.
 		}

--- a/apps/server/src/chat/mcp.ts
+++ b/apps/server/src/chat/mcp.ts
@@ -69,16 +69,19 @@ export interface McpDiscovery {
 }
 
 /**
- * Lists what a connected server offers, asking only for the capabilities it
- * declared during initialize. A server without the `prompts` capability
- * answers `prompts/list` with JSON-RPC -32601 (Method not found); listing
- * everything unconditionally turned that into a thrown error, and a
- * tools-only server (most search or fetch servers) was silently dropped.
+ * Lists what a connected server offers. tools/list is always asked, as
+ * before: proxies, gateways and older frameworks answer it without
+ * advertising the `tools` capability, and trusting the declaration there
+ * would drop every tool with no error. The optional prompts/resources lists
+ * are asked only when declared: a server without the `prompts` capability
+ * answers `prompts/list` with JSON-RPC -32601 (Method not found), and
+ * listing it unconditionally turned that into a thrown error that silently
+ * dropped every tools-only server (most search or fetch servers).
  */
 export async function discoverMcpServer(client: Client): Promise<McpDiscovery> {
 	const declared = client.getServerCapabilities() ?? {};
 	const [tools, prompts, resources] = await Promise.all([
-		declared.tools ? client.listTools() : Promise.resolve({ tools: [] }),
+		client.listTools(),
 		declared.prompts ? client.listPrompts() : Promise.resolve({ prompts: [] }),
 		declared.resources
 			? client.listResources()


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
What would you like me to do with the MCP capability-gating changes — review, test, or something else?
<!-- kody-pr-summary:end -->